### PR TITLE
refactor: rename componentDir to entryDir and fix pathToExportName

### DIFF
--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -2,7 +2,7 @@
  * Configuration for Visle plugin
  */
 export interface VisleConfig {
-  componentDir?: string
+  entryDir?: string
   serverOutDir?: string
   clientOutDir?: string
 }
@@ -13,7 +13,7 @@ export interface VisleConfig {
 export type ResolvedVisleConfig = Required<VisleConfig>
 
 export const defaultConfig: ResolvedVisleConfig = {
-  componentDir: 'components',
+  entryDir: 'components',
   clientOutDir: 'dist/client',
   serverOutDir: 'dist/server',
 }

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -22,12 +22,12 @@ export function generateClientVirtualEntryCode(componentIds: string[]): string {
 }
 
 export function generateServerVirtualEntryCode(
-  componentDir: string,
+  entryDir: string,
   componentIds: string[],
 ): string {
   return componentIds
     .map((id) => {
-      const exportName = pathToExportName(path.relative(componentDir, id))
+      const exportName = pathToExportName(path.relative(entryDir, id))
       return `export { default as ${exportName} } from '${id}'`
     })
     .join('\n')

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -21,10 +21,7 @@ export function generateClientVirtualEntryCode(componentIds: string[]): string {
   )
 }
 
-export function generateServerVirtualEntryCode(
-  entryDir: string,
-  componentIds: string[],
-): string {
+export function generateServerVirtualEntryCode(entryDir: string, componentIds: string[]): string {
   return componentIds
     .map((id) => {
       const exportName = pathToExportName(path.relative(entryDir, id))

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -35,7 +35,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
       // Find island components for client entry points
       const islandPaths = resolvePattern(
         '/**/*.island.vue',
-        path.join(root, resolvedConfig.componentDir),
+        path.join(root, resolvedConfig.entryDir),
       )
 
       return {

--- a/src/build/plugins/island.ts
+++ b/src/build/plugins/island.ts
@@ -93,7 +93,7 @@ export function islandPlugin(config: ResolvedVisleConfig): Plugin {
       if (envName === 'style') {
         if (id === clientVirtualEntryId) {
           return generateClientVirtualEntryCode(
-            resolveServerComponentIds(path.join(viteConfig.root, config.componentDir)),
+            resolveServerComponentIds(path.join(viteConfig.root, config.entryDir)),
           )
         }
         return null
@@ -109,8 +109,8 @@ export function islandPlugin(config: ResolvedVisleConfig): Plugin {
       if (envName === 'server') {
         if (id === serverVirtualEntryId) {
           return generateServerVirtualEntryCode(
-            path.join(viteConfig.root, config.componentDir),
-            resolveServerComponentIds(path.join(viteConfig.root, config.componentDir)),
+            path.join(viteConfig.root, config.entryDir),
+            resolveServerComponentIds(path.join(viteConfig.root, config.entryDir)),
           )
         }
 
@@ -124,7 +124,7 @@ export function islandPlugin(config: ResolvedVisleConfig): Plugin {
       // Dev client environment — load both virtual entries
       if (id === clientVirtualEntryId) {
         return generateClientVirtualEntryCode(
-          resolveServerComponentIds(path.join(viteConfig.root, config.componentDir)),
+          resolveServerComponentIds(path.join(viteConfig.root, config.entryDir)),
         )
       }
 

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -41,7 +41,7 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
       const visleConfig = getVisleConfig(devServer.config)
 
       const modulePath = resolveDevComponentPath(
-        path.join(devServer.config.root, visleConfig.componentDir),
+        path.join(devServer.config.root, visleConfig.entryDir),
         componentPath,
       )
 

--- a/test/build/vite.config.ts
+++ b/test/build/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     visle({
       clientOutDir: 'dist/client',
-      componentDir: '',
+      entryDir: '',
     }),
   ],
 })


### PR DESCRIPTION
## Summary
- Rename `componentDir` config option to `entryDir` across source and tests (default remains `'components'` — no behavior change)
- Fix `pathToExportName` to use single-pass character mapping, avoiding collisions from chained `replaceAll` calls

Part 1 of the island-directive branch split (#45).

## Test plan
- All existing tests pass without modification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Configuration field `componentDir` renamed to `entryDir` — update your configuration files accordingly.

* **Improvements**
  * Path transformation logic refactored for improved consistency in component identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->