### PR TITLE
feat: support arbitrary entry file name

### DIFF
--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -22,9 +22,7 @@ export function generateClientVirtualEntryCode(componentIds: string[]): string {
 }
 
 export function generateServerVirtualEntryCode(entryDir: string, componentIds: string[]): string {
-  const imports = componentIds
-    .map((id, i) => `import _${i} from '${id}'`)
-    .join('\n')
+  const imports = componentIds.map((id, i) => `import _${i} from '${id}'`).join('\n')
 
   const entries = componentIds
     .map((id, i) => {

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -2,8 +2,6 @@ import path from 'node:path'
 
 import { normalizePath } from 'vite'
 
-import { pathToExportName } from './paths.js'
-
 export const clientVirtualEntryId = '\0@visle/client-entry'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
@@ -24,12 +22,18 @@ export function generateClientVirtualEntryCode(componentIds: string[]): string {
 }
 
 export function generateServerVirtualEntryCode(entryDir: string, componentIds: string[]): string {
-  return componentIds
-    .map((id) => {
-      const exportName = pathToExportName(path.relative(entryDir, id))
-      return `export { default as ${exportName} } from '${id}'`
-    })
+  const imports = componentIds
+    .map((id, i) => `import _${i} from '${id}'`)
     .join('\n')
+
+  const entries = componentIds
+    .map((id, i) => {
+      const key = path.relative(entryDir, id).replace(/\.vue$/, '')
+      return `  '${key}': _${i}`
+    })
+    .join(',\n')
+
+  return `${imports}\nexport default {\n${entries}\n}`
 }
 
 export const serverWrapPrefix = '\0visle:server-wrap:'

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -26,7 +26,7 @@ export function generateServerVirtualEntryCode(entryDir: string, componentIds: s
 
   const entries = componentIds
     .map((id, i) => {
-      const key = path.relative(entryDir, id).replace(/\.vue$/, '')
+      const key = normalizePath(path.relative(entryDir, id).replace(/\.vue$/, ''))
       return `  '${key}': _${i}`
     })
     .join(',\n')

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -22,40 +22,6 @@ export const customElementEntryPath = path.resolve(
 // -----------------------------
 
 /**
- * Converts a component path to a valid export name
- */
-export function pathToExportName(targetPath: string): string {
-  const stripped = targetPath.replace(/^\//, '').replace(/\.vue$/, '')
-
-  // Single-pass character mapping to avoid collisions from chained replacements
-  // (e.g. chained replaceAll would turn both `_/` and `-` into `___`).
-  let replaced = ''
-  for (const ch of stripped) {
-    switch (ch) {
-      case '$':
-        replaced += '$$'
-        break
-      case '.':
-        replaced += '$d'
-        break
-      case '_':
-        replaced += '$u'
-        break
-      case '-':
-        replaced += '$h'
-        break
-      case '/':
-        replaced += '_'
-        break
-      default:
-        replaced += ch
-    }
-  }
-
-  return `_${replaced}`
-}
-
-/**
  * Resolves glob patterns to find files
  */
 export function resolvePattern(pattern: string | string[], root: string): string[] {

--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -50,7 +50,7 @@ describe('createRender', () => {
         'dist/server/visle-manifest.json': emptyManifest,
         'dist/server/server-entry.js': `
           import { defineComponent, h } from 'vue'
-          export const _Comp = defineComponent({
+          export default { Comp: defineComponent({
             props: {
               msg: {
                 type: String,
@@ -60,7 +60,7 @@ describe('createRender', () => {
             render() {
               return h('div', {}, [this.msg])
             },
-          })`,
+          }) }`,
       })
 
       const result = await render('Comp', { msg: 'Hello' })
@@ -77,11 +77,11 @@ describe('createRender', () => {
         'dist/server/visle-manifest.json': emptyManifest,
         'dist/server/server-entry.js': `
           import { defineComponent, h } from 'vue'
-          export const _Comp = defineComponent({
+          export default { Comp: defineComponent({
             render() {
               return h('div', {}, ['Hello'])
             },
-          })`,
+          }) }`,
       })
 
       const result = await render('Comp')
@@ -98,11 +98,11 @@ describe('createRender', () => {
         'dist/server/visle-manifest.json': emptyManifest,
         'dist/server/server-entry.mjs': `
           import { defineComponent, h } from 'vue'
-          export const _Comp = defineComponent({
+          export default { Comp: defineComponent({
             render() {
               return h('div', {}, ['Hello'])
             },
-          })`,
+          }) }`,
       })
 
       const result = await render('Comp')
@@ -119,7 +119,7 @@ describe('createRender', () => {
         'dist/server/visle-manifest.json': emptyManifest,
         'dist/server/server-entry.js': `
           import { defineComponent, h } from 'vue'
-          export const _Comp = defineComponent({
+          export default { Comp: defineComponent({
             render() {
               return h('html', {}, [
                 h('head', {}, [
@@ -132,7 +132,7 @@ describe('createRender', () => {
                 ]),
               ])
             },
-          })`,
+          }) }`,
       })
 
       const result = await render('Comp')

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -2,7 +2,7 @@ import { Component, createApp } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
 import { defaultConfig } from '../build/config.js'
-import { pathToExportName, resolveServerDistPath } from '../build/paths.js'
+import { resolveServerDistPath } from '../build/paths.js'
 import { RuntimeManifest, loadManifest } from './manifest.js'
 import { transformWithRenderContext } from './transform.js'
 
@@ -52,7 +52,7 @@ export function createRender(options: RenderOptions = {}): RenderFunction {
       const serverOutDir = options.serverOutDir ?? defaultConfig.serverOutDir
 
       return import(/* @vite-ignore */ resolveServerDistPath(serverOutDir)).then(
-        (m) => m[pathToExportName(componentPath)],
+        (m) => m.default[componentPath],
       )
     },
 

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -155,6 +155,12 @@ exports[`Dev Server SSR > 'Nested island' 1`] = `
 </div>
 `;
 
+exports[`Dev Server SSR > 'Non-ascii file name' 1`] = `
+<p>
+  Non-ascii file name
+</p>
+`;
+
 exports[`Dev Server SSR > 'Server component with slot' 1`] = `
 <div class="layout">
   <header>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -179,6 +179,16 @@ exports[`Production Build SSR > 'Nested island' 1`] = `
 </div>
 `;
 
+exports[`Production Build SSR > 'Non-ascii file name' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<p>
+  Non-ascii file name
+</p>
+`;
+
 exports[`Production Build SSR > 'Server component with slot' 1`] = `
 <link
   rel="stylesheet"

--- a/test/fixtures/pages/テスト.vue
+++ b/test/fixtures/pages/テスト.vue
@@ -1,0 +1,3 @@
+<template>
+  <p>Non-ascii file name</p>
+</template>

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -23,6 +23,7 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'CSS modules', component: 'with-css-module' },
   { name: 'Nested island', component: 'with-nested-island' },
   { name: 'Multiple islands on the same page', component: 'with-multiple-islands' },
+  { name: 'Non-ascii file name', component: 'テスト' },
 ]
 
 /**


### PR DESCRIPTION
## Summary
- Replace named exports with a default export object map in the server virtual entry, removing the `pathToExportName` encoding. This allows component file names with non-ASCII characters (e.g., Japanese) or special characters to work correctly.
- Remove the now-unused `pathToExportName` function from `src/build/paths.ts`.
- Add a test case with a non-ASCII file name (`テスト.vue`).

## Test plan
- [x] Existing dev and prod snapshot tests updated and passing
- [x] New "Non-ascii file name" test case added for both dev and prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vue components with non-ASCII filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->