### PR TITLE
feat: support normal <script> blocks in island components

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "vite": "^7.3.1"
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.0",
+    "@babel/types": "^7.29.0",
     "@types/connect": "^3.4.38",
     "@types/diffable-html": "^5.0.2",
     "@types/express": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.0)
     devDependencies:
+      '@babel/parser':
+        specifier: ^7.29.0
+        version: 7.29.0
+      '@babel/types':
+        specifier: ^7.29.0
+        version: 7.29.0
       '@types/connect':
         specifier: ^3.4.38
         version: 3.4.38
@@ -81,10 +87,6 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/types@7.28.6':
-    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -1172,11 +1174,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/types@7.28.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -1827,7 +1824,7 @@ snapshots:
   magicast@0.5.1:
     dependencies:
       '@babel/parser': 7.29.0
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -1,11 +1,7 @@
 import path from 'node:path'
 
-import type { ElementNode, TemplateChildNode } from '@vue/compiler-core'
-import { NodeTypes } from '@vue/compiler-core'
 import type { Plugin, ResolvedConfig } from 'vite'
-import type { ParserPlugin } from '@babel/parser'
-import type { ObjectExpression } from '@babel/types'
-import { babelParse, compileScript, parse, type SFCDescriptor } from 'vue/compiler-sfc'
+import { parse } from 'vue/compiler-sfc'
 
 import {
   generateIslandWrapperCodeJS,
@@ -13,15 +9,12 @@ import {
   islandWrapPrefix,
   serverWrapPrefix,
 } from '../generate.js'
+import { buildImportMap, findVClientElements } from './sfc-analysis.js'
 import { customElementEntryPath, parseId } from '../paths.js'
 
 interface ServerTransformPluginResult {
   plugin: Plugin
   islandPaths: Set<string>
-}
-
-interface ImportInfo {
-  source: string
 }
 
 /**
@@ -211,152 +204,4 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
   }
 
   return { plugin, islandPaths }
-}
-
-/**
- * Parses import declarations from <script setup> or <script>
- * to build a tag-name-to-import mapping.
- */
-function buildImportMap(descriptor: SFCDescriptor, id: string): Map<string, ImportInfo> {
-  const map = new Map<string, ImportInfo>()
-
-  if (descriptor.scriptSetup) {
-    const { imports } = compileScript(descriptor, { id })
-
-    if (imports) {
-      for (const [name, binding] of Object.entries(imports)) {
-        if (binding.source.endsWith('.vue')) {
-          map.set(name, {
-            source: binding.source,
-          })
-        }
-      }
-    }
-
-    return map
-  }
-
-  if (descriptor.script) {
-    const lang = descriptor.script.lang
-    const plugins: ParserPlugin[] = []
-    if (lang === 'ts' || lang === 'tsx') {
-      plugins.push('typescript')
-    }
-    if (lang === 'jsx' || lang === 'tsx') {
-      plugins.push('jsx')
-    }
-
-    const ast = babelParse(descriptor.script.content, {
-      sourceType: 'module',
-      plugins,
-    })
-
-    // Step 1: Build importName → source map from import declarations
-    const importSources = new Map<string, string>()
-    for (const node of ast.program.body) {
-      if (node.type === 'ImportDeclaration') {
-        const source = node.source.value
-        if (typeof source === 'string' && source.endsWith('.vue')) {
-          for (const specifier of node.specifiers) {
-            if (specifier.type === 'ImportDefaultSpecifier') {
-              importSources.set(specifier.local.name, source)
-            }
-          }
-        }
-      }
-    }
-
-    // Step 2: Find options object from export default
-    // Supports: export default { ... } and export default fn({ ... })
-    let optionsObject: ObjectExpression | undefined
-    for (const node of ast.program.body) {
-      if (node.type === 'ExportDefaultDeclaration') {
-        if (node.declaration.type === 'ObjectExpression') {
-          optionsObject = node.declaration
-        } else if (
-          node.declaration.type === 'CallExpression'
-          && node.declaration.arguments[0]?.type === 'ObjectExpression'
-        ) {
-          optionsObject = node.declaration.arguments[0]
-        }
-      }
-    }
-
-    // Step 3: Extract components option to get tag name mappings
-    const componentMap = new Map<string, string>() // tagName → importName
-    if (optionsObject) {
-      const componentsProp = optionsObject.properties.find(
-        (p) =>
-          p.type === 'ObjectProperty'
-          && ((p.key.type === 'Identifier' && p.key.name === 'components')
-            || (p.key.type === 'StringLiteral' && p.key.value === 'components')),
-      )
-      if (
-        componentsProp?.type === 'ObjectProperty'
-        && componentsProp.value.type === 'ObjectExpression'
-      ) {
-        for (const prop of componentsProp.value.properties) {
-          if (prop.type !== 'ObjectProperty' || prop.value.type !== 'Identifier') {
-            continue
-          }
-          const keyName =
-            prop.key.type === 'Identifier'
-              ? prop.key.name
-              : prop.key.type === 'StringLiteral'
-                ? prop.key.value
-                : undefined
-          if (keyName) {
-            componentMap.set(keyName, prop.value.name)
-          }
-        }
-      }
-    }
-
-    // Step 4: Combine — use componentMap if available, otherwise fall back to import names
-    if (componentMap.size > 0) {
-      for (const [tagName, importName] of componentMap) {
-        const source = importSources.get(importName)
-        if (source) {
-          map.set(tagName, { source })
-        }
-      }
-    } else {
-      for (const [importName, source] of importSources) {
-        map.set(importName, { source })
-      }
-    }
-  }
-
-  return map
-}
-
-/**
- * Recursively finds elements with v-client:load directive.
- */
-function findVClientElements(children: TemplateChildNode[]): ElementNode[] {
-  const results: ElementNode[] = []
-
-  for (const child of children) {
-    if (child.type !== NodeTypes.ELEMENT) {
-      continue
-    }
-
-    const hasVClient = child.props.some(
-      (prop) =>
-        prop.type === NodeTypes.DIRECTIVE &&
-        prop.name === 'client' &&
-        prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
-        prop.arg.content === 'load',
-    )
-
-    if (hasVClient) {
-      results.push(child)
-    }
-
-    if (child.children.length > 0) {
-      results.push(...findVClientElements(child.children))
-    }
-  }
-
-  return results
 }

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -9,8 +9,8 @@ import {
   islandWrapPrefix,
   serverWrapPrefix,
 } from '../generate.js'
-import { buildImportMap, findVClientElements } from './sfc-analysis.js'
 import { customElementEntryPath, parseId } from '../paths.js'
+import { buildImportMap, findVClientElements } from './sfc-analysis.js'
 
 interface ServerTransformPluginResult {
   plugin: Plugin

--- a/src/build/plugins/sfc-analysis.test.ts
+++ b/src/build/plugins/sfc-analysis.test.ts
@@ -1,0 +1,374 @@
+import { describe, test, expect } from 'vitest'
+import { parse } from 'vue/compiler-sfc'
+
+import { buildImportMap, findVClientElements } from './sfc-analysis.ts'
+
+function parseSfc(code: string) {
+  return parse(code).descriptor
+}
+
+describe('buildImportMap', () => {
+  describe('script setup', () => {
+    test('extracts .vue imports', () => {
+      const descriptor = parseSfc(`
+        <script setup>
+        import Counter from './Counter.vue'
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('extracts multiple .vue imports', () => {
+      const descriptor = parseSfc(`
+        <script setup>
+        import Counter from './Counter.vue'
+        import Header from '../components/Header.vue'
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(2)
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Header')).toEqual({ source: '../components/Header.vue' })
+    })
+
+    test('ignores non-.vue imports', () => {
+      const descriptor = parseSfc(`
+        <script setup>
+        import { ref } from 'vue'
+        import utils from './utils.ts'
+        import Counter from './Counter.vue'
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(1)
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('returns empty map when no .vue imports', () => {
+      const descriptor = parseSfc(`
+        <script setup>
+        import { ref } from 'vue'
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(0)
+    })
+  })
+
+  describe('script (options API)', () => {
+    test('extracts imports with components option', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports renamed components', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import OptionsCounter from './OptionsCounter.vue'
+        export default {
+          components: {
+            RenamedCounter: OptionsCounter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(1)
+      expect(map.get('RenamedCounter')).toEqual({ source: './OptionsCounter.vue' })
+      expect(map.has('OptionsCounter')).toBe(false)
+    })
+
+    test('supports string-literal keys in components', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            'my-counter': Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('my-counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports string-literal "components" key', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        export default {
+          'components': {
+            Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('falls back to import names without components option', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        export default {
+          name: 'MyPage',
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('falls back to import names without export default', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports export default fn({ ... }) pattern', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        import { defineComponent } from 'vue'
+        export default defineComponent({
+          components: {
+            Counter,
+          },
+        })
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports TypeScript lang', () => {
+      const descriptor = parseSfc(`
+        <script lang="ts">
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports JSX lang', () => {
+      const descriptor = parseSfc(`
+        <script lang="jsx">
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('supports TSX lang', () => {
+      const descriptor = parseSfc(`
+        <script lang="tsx">
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            Counter,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+
+    test('ignores named imports (non-default)', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import { Counter } from './Counter.vue'
+        export default {}
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(0)
+    })
+
+    test('handles multiple imports with components mapping', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        import Header from './Header.vue'
+        export default {
+          components: {
+            Counter,
+            MyHeader: Header,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(2)
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('MyHeader')).toEqual({ source: './Header.vue' })
+    })
+
+    test('ignores components entry referencing unknown import', () => {
+      const descriptor = parseSfc(`
+        <script>
+        import Counter from './Counter.vue'
+        export default {
+          components: {
+            Counter,
+            Unknown: SomeOtherComponent,
+          },
+        }
+        </script>
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(1)
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+    })
+  })
+
+  describe('no script', () => {
+    test('returns empty map for template-only SFC', () => {
+      const descriptor = parseSfc(`
+        <template><div /></template>
+      `)
+      const map = buildImportMap(descriptor, 'test.vue')
+      expect(map.size).toBe(0)
+    })
+  })
+})
+
+describe('findVClientElements', () => {
+  function parseTemplate(template: string) {
+    const descriptor = parseSfc(`<template>${template}</template>`)
+    return descriptor.template!.ast!.children
+  }
+
+  test('finds element with v-client:load', () => {
+    const children = parseTemplate('<Counter v-client:load />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0].tag).toBe('Counter')
+  })
+
+  test('finds multiple elements with v-client:load', () => {
+    const children = parseTemplate(`
+      <Counter v-client:load />
+      <Header v-client:load />
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(2)
+    expect(results.map((r) => r.tag)).toEqual(['Counter', 'Header'])
+  })
+
+  test('ignores elements without v-client:load', () => {
+    const children = parseTemplate(`
+      <Counter />
+      <Header v-client:load />
+      <Footer />
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0].tag).toBe('Header')
+  })
+
+  test('finds nested elements with v-client:load', () => {
+    const children = parseTemplate(`
+      <div>
+        <section>
+          <Counter v-client:load />
+        </section>
+      </div>
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0].tag).toBe('Counter')
+  })
+
+  test('finds deeply nested and top-level elements', () => {
+    const children = parseTemplate(`
+      <Header v-client:load />
+      <div>
+        <Counter v-client:load />
+      </div>
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(2)
+    expect(results.map((r) => r.tag)).toEqual(['Header', 'Counter'])
+  })
+
+  test('returns empty array when no v-client:load elements', () => {
+    const children = parseTemplate(`
+      <div>
+        <Counter />
+        <Header />
+      </div>
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(0)
+  })
+
+  test('returns empty array for empty template', () => {
+    const children = parseTemplate('')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(0)
+  })
+
+  test('ignores directives with different names', () => {
+    const children = parseTemplate(`
+      <Counter v-if="true" />
+      <Header v-client:load />
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0].tag).toBe('Header')
+  })
+
+  test('finds v-client:load on native HTML elements', () => {
+    const children = parseTemplate('<div v-client:load />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0].tag).toBe('div')
+  })
+})

--- a/src/build/plugins/sfc-analysis.test.ts
+++ b/src/build/plugins/sfc-analysis.test.ts
@@ -289,7 +289,7 @@ describe('findVClientElements', () => {
     const children = parseTemplate('<Counter v-client:load />')
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0].tag).toBe('Counter')
+    expect(results[0]!.tag).toBe('Counter')
   })
 
   test('finds multiple elements with v-client:load', () => {
@@ -310,7 +310,7 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0].tag).toBe('Header')
+    expect(results[0]!.tag).toBe('Header')
   })
 
   test('finds nested elements with v-client:load', () => {
@@ -323,7 +323,7 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0].tag).toBe('Counter')
+    expect(results[0]!.tag).toBe('Counter')
   })
 
   test('finds deeply nested and top-level elements', () => {
@@ -362,13 +362,13 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0].tag).toBe('Header')
+    expect(results[0]!.tag).toBe('Header')
   })
 
   test('finds v-client:load on native HTML elements', () => {
     const children = parseTemplate('<div v-client:load />')
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0].tag).toBe('div')
+    expect(results[0]!.tag).toBe('div')
   })
 })

--- a/src/build/plugins/sfc-analysis.ts
+++ b/src/build/plugins/sfc-analysis.ts
@@ -1,0 +1,159 @@
+import type { ParserPlugin } from '@babel/parser'
+import type { ObjectExpression } from '@babel/types'
+import type { ElementNode, TemplateChildNode } from '@vue/compiler-core'
+import { NodeTypes } from '@vue/compiler-core'
+import { babelParse, compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
+
+export interface ImportInfo {
+  source: string
+}
+
+/**
+ * Parses import declarations from <script setup> or <script>
+ * to build a tag-name-to-import mapping.
+ */
+export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<string, ImportInfo> {
+  const map = new Map<string, ImportInfo>()
+
+  if (descriptor.scriptSetup) {
+    const { imports } = compileScript(descriptor, { id })
+
+    if (imports) {
+      for (const [name, binding] of Object.entries(imports)) {
+        if (binding.source.endsWith('.vue')) {
+          map.set(name, {
+            source: binding.source,
+          })
+        }
+      }
+    }
+
+    return map
+  }
+
+  if (descriptor.script) {
+    const lang = descriptor.script.lang
+    const plugins: ParserPlugin[] = []
+    if (lang === 'ts' || lang === 'tsx') {
+      plugins.push('typescript')
+    }
+    if (lang === 'jsx' || lang === 'tsx') {
+      plugins.push('jsx')
+    }
+
+    const ast = babelParse(descriptor.script.content, {
+      sourceType: 'module',
+      plugins,
+    })
+
+    // Step 1: Build importName → source map from import declarations
+    const importSources = new Map<string, string>()
+    for (const node of ast.program.body) {
+      if (node.type === 'ImportDeclaration') {
+        const source = node.source.value
+        if (typeof source === 'string' && source.endsWith('.vue')) {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportDefaultSpecifier') {
+              importSources.set(specifier.local.name, source)
+            }
+          }
+        }
+      }
+    }
+
+    // Step 2: Find options object from export default
+    // Supports: export default { ... } and export default fn({ ... })
+    let optionsObject: ObjectExpression | undefined
+    for (const node of ast.program.body) {
+      if (node.type === 'ExportDefaultDeclaration') {
+        if (node.declaration.type === 'ObjectExpression') {
+          // export default { ... }
+          optionsObject = node.declaration
+        } else if (
+          node.declaration.type === 'CallExpression' &&
+          node.declaration.arguments[0]?.type === 'ObjectExpression'
+        ) {
+          // export default defineComponent({ ... })
+          optionsObject = node.declaration.arguments[0]
+        }
+      }
+    }
+
+    // Step 3: Extract components option to get tag name mappings
+    const componentMap = new Map<string, string>() // tagName → importName
+    if (optionsObject) {
+      const componentsProp = optionsObject.properties.find(
+        (p) =>
+          p.type === 'ObjectProperty' &&
+          ((p.key.type === 'Identifier' && p.key.name === 'components') ||
+            (p.key.type === 'StringLiteral' && p.key.value === 'components')),
+      )
+      if (
+        componentsProp?.type === 'ObjectProperty' &&
+        componentsProp.value.type === 'ObjectExpression'
+      ) {
+        for (const prop of componentsProp.value.properties) {
+          if (prop.type !== 'ObjectProperty' || prop.value.type !== 'Identifier') {
+            continue
+          }
+          const keyName =
+            prop.key.type === 'Identifier'
+              ? prop.key.name
+              : prop.key.type === 'StringLiteral'
+                ? prop.key.value
+                : undefined
+          if (keyName) {
+            componentMap.set(keyName, prop.value.name)
+          }
+        }
+      }
+    }
+
+    // Step 4: Combine — use componentMap if available, otherwise fall back to import names
+    if (componentMap.size > 0) {
+      for (const [tagName, importName] of componentMap) {
+        const source = importSources.get(importName)
+        if (source) {
+          map.set(tagName, { source })
+        }
+      }
+    } else {
+      for (const [importName, source] of importSources) {
+        map.set(importName, { source })
+      }
+    }
+  }
+
+  return map
+}
+
+/**
+ * Recursively finds elements with v-client:load directive.
+ */
+export function findVClientElements(children: TemplateChildNode[]): ElementNode[] {
+  const results: ElementNode[] = []
+
+  for (const child of children) {
+    if (child.type !== NodeTypes.ELEMENT) {
+      continue
+    }
+
+    const hasVClient = child.props.some(
+      (prop) =>
+        prop.type === NodeTypes.DIRECTIVE &&
+        prop.name === 'client' &&
+        prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+        prop.arg.content === 'load',
+    )
+
+    if (hasVClient) {
+      results.push(child)
+    }
+
+    if (child.children.length > 0) {
+      results.push(...findVClientElements(child.children))
+    }
+  }
+
+  return results
+}

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -113,6 +113,44 @@ exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 </div>
 `;
 
+exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
+<script
+  type="module"
+  src="/@visle/entry"
+  async
+>
+</script>
+<div>
+  <h1>
+    Options API Renamed Page
+  </h1>
+  <vue-island entry="/components/OptionsCounter.vue">
+    <button>
+      Options Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
+exports[`Dev Server SSR > 'Island with options API' 1`] = `
+<script
+  type="module"
+  src="/@visle/entry"
+  async
+>
+</script>
+<div>
+  <h1>
+    Options API Page
+  </h1>
+  <vue-island entry="/components/OptionsCounter.vue">
+    <button>
+      Options Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Dev Server SSR > 'Island with props' 1`] = `
 <script
   type="module"

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -129,6 +129,52 @@ exports[`Production Build SSR > 'Island with alias import' 1`] = `
 </div>
 `;
 
+exports[`Production Build SSR > 'Island with options API renamed compo…' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<script
+  type="module"
+  src="/assets/custom-element-[hash].js"
+  async
+>
+</script>
+<div>
+  <h1>
+    Options API Renamed Page
+  </h1>
+  <vue-island entry="/assets/OptionsCounter-[hash].js">
+    <button>
+      Options Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
+exports[`Production Build SSR > 'Island with options API' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<script
+  type="module"
+  src="/assets/custom-element-[hash].js"
+  async
+>
+</script>
+<div>
+  <h1>
+    Options API Page
+  </h1>
+  <vue-island entry="/assets/OptionsCounter-[hash].js">
+    <button>
+      Options Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Production Build SSR > 'Island with props' 1`] = `
 <link
   rel="stylesheet"
@@ -278,6 +324,7 @@ exports[`Production Build SSR > Build output files 1`] = `
   "assets/CounterB-[hash].js",
   "assets/Inner-[hash].js",
   "assets/NamedExportIsland-[hash].js",
+  "assets/OptionsCounter-[hash].js",
   "assets/Outer-[hash].js",
   "assets/StyledCounter-[hash].js",
   "assets/_plugin-vue_export-helper-[hash].js",
@@ -300,6 +347,7 @@ exports[`Production Build SSR > Build output files 2`] = `
     "components/CounterB.vue": "assets/CounterB-[hash].js",
     "components/Inner.vue": "assets/Inner-[hash].js",
     "components/NamedExportIsland.vue": "assets/NamedExportIsland-[hash].js",
+    "components/OptionsCounter.vue": "assets/OptionsCounter-[hash].js",
     "components/Outer.vue": "assets/Outer-[hash].js",
     "components/StyledCounter.vue": "assets/StyledCounter-[hash].js",
   },

--- a/test/fixtures/components/OptionsCounter.vue
+++ b/test/fixtures/components/OptionsCounter.vue
@@ -1,0 +1,14 @@
+<script>
+export default {
+  props: {
+    count: {
+      type: Number,
+      default: 0,
+    },
+  },
+}
+</script>
+
+<template>
+  <button>Options Count: {{ count }}</button>
+</template>

--- a/test/fixtures/pages/with-options-api-renamed.vue
+++ b/test/fixtures/pages/with-options-api-renamed.vue
@@ -1,0 +1,16 @@
+<script>
+import OptionsCounter from '../components/OptionsCounter.vue'
+
+export default {
+  components: {
+    RenamedCounter: OptionsCounter,
+  },
+}
+</script>
+
+<template>
+  <div>
+    <h1>Options API Renamed Page</h1>
+    <RenamedCounter v-client:load />
+  </div>
+</template>

--- a/test/fixtures/pages/with-options-api.vue
+++ b/test/fixtures/pages/with-options-api.vue
@@ -1,0 +1,16 @@
+<script>
+import OptionsCounter from '../components/OptionsCounter.vue'
+
+export default {
+  components: {
+    OptionsCounter,
+  },
+}
+</script>
+
+<template>
+  <div>
+    <h1>Options API Page</h1>
+    <OptionsCounter v-client:load />
+  </div>
+</template>

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -26,6 +26,8 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'Non-ascii file name', component: 'テスト' },
   { name: 'Island with alias import', component: 'with-island-alias' },
   { name: 'Named export', component: 'named-export' },
+  { name: 'Island with options API', component: 'with-options-api' },
+  { name: 'Island with options API renamed component', component: 'with-options-api-renamed' },
 ]
 
 /**


### PR DESCRIPTION
## Summary

- Extend `buildImportMap` in `server-transform.ts` to handle Options API components using normal `<script>` blocks (in addition to existing `<script setup>` support)
- Parse import declarations and the `components` option to resolve tag-to-source mappings, supporting both shorthand (`{ Foo }`) and renamed (`{ Bar: Foo }`) forms
- Support both `export default { ... }` and `export default defineComponent({ ... })` patterns

## Test plan

- [x] Added `OptionsCounter.vue` island component fixture using Options API
- [x] Added `with-options-api.vue` page fixture (same-name import)
- [x] Added `with-options-api-renamed.vue` page fixture (renamed component in `components` option)
- [x] Both dev and prod integration tests pass (56/56)
- [x] Snapshots confirm `<vue-island>` wrapping with correct entry paths for both cases
- [x] Renamed component test verifies the `entry` attribute uses the real component path, not the renamed tag name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for Vue Options API components in island rendering and component detection.
  * Added example components/pages demonstrating Options API usage and renamed component aliases.

* **Refactor**
  * SFC parsing and component-detection logic consolidated into a shared analysis utility.

* **Tests**
  * Added comprehensive tests covering Options API cases, renamed aliases, and v-client usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->