### PR TITLE
feat: support alias imports in island components

### DIFF
--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -70,7 +70,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       islandImportMap.clear()
     },
 
-    resolveId(id, importer) {
+    async resolveId(id, importer) {
       // Redirect .vue imports to server wrapper virtual modules.
       // Skip when the importer is a wrapper module to avoid infinite recursion.
       const { fileName, query } = parseId(id)
@@ -79,7 +79,15 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         const isFromWrapper =
           importer?.startsWith(serverWrapPrefix) || importer?.startsWith(islandWrapPrefix)
         if (!isFromWrapper) {
-          const absolutePath = toAbsolutePath(fileName, importer)
+          let absolutePath: string
+          if (path.isAbsolute(fileName) || fileName.startsWith('.')) {
+            absolutePath = toAbsolutePath(fileName, importer)
+          } else {
+            // Alias or bare specifier — delegate to Vite's resolver
+            const resolved = await this.resolve(id, importer, { skipSelf: true })
+            if (!resolved) return null
+            absolutePath = resolved.id
+          }
 
           // Check if this import was marked as an island by the transform hook.
           // The importer may include a query (e.g. ?vue&type=script), so strip it.
@@ -118,7 +126,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       }
     },
 
-    transform(code, id) {
+    async transform(code, id) {
       const { fileName, query } = parseId(id)
 
       if (!fileName.endsWith('.vue')) {
@@ -146,11 +154,36 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         return null
       }
 
-      for (const node of matches) {
-        const tag = node.tag
+      // Resolve alias import sources in parallel
+      const resolveResults = await Promise.all(
+        matches.map(async (node) => {
+          const importInfo = importMap.get(node.tag)
+          if (!importInfo) return { tag: node.tag, importInfo: undefined, resolvedPath: undefined }
 
-        // Check if this is a statically imported component
-        const importInfo = importMap.get(tag)
+          const source = importInfo.source
+          let resolvedPath: string | undefined
+          if (path.isAbsolute(source) || source.startsWith('.')) {
+            resolvedPath = path.resolve(path.dirname(fileName), source)
+          } else {
+            // Alias or bare specifier — delegate to Vite's resolver
+            const resolved = await this.resolve(source, id, { skipSelf: true })
+            if (resolved) {
+              // Our resolveId wraps .vue in virtual module prefixes — unwrap to get the real path
+              const resolvedId = resolved.id
+              if (resolvedId.startsWith(serverWrapPrefix)) {
+                resolvedPath = resolvedId.slice(serverWrapPrefix.length)
+              } else if (resolvedId.startsWith(islandWrapPrefix)) {
+                resolvedPath = resolvedId.slice(islandWrapPrefix.length)
+              } else {
+                resolvedPath = resolvedId
+              }
+            }
+          }
+          return { tag: node.tag, importInfo, resolvedPath }
+        }),
+      )
+
+      for (const { tag, importInfo, resolvedPath } of resolveResults) {
         if (!importInfo) {
           this.warn(
             `v-client:load on "${tag}" is not supported. ` +
@@ -159,8 +192,8 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
           continue
         }
 
-        // Resolve the absolute path of the component and collect for islands build
-        const resolvedPath = path.resolve(path.dirname(fileName), importInfo.source)
+        if (!resolvedPath) continue
+
         islandPaths.add(resolvedPath)
 
         // Record in the island import map so resolveId can redirect this import

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -187,7 +187,12 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
           continue
         }
 
-        if (!resolvedPath) continue
+        if (!resolvedPath) {
+          this.warn(
+            `Could not resolve import "${importInfo.source}" for v-client:load component "${tag}" in ${fileName}`,
+          )
+          continue
+        }
 
         islandPaths.add(resolvedPath)
 

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -94,6 +94,25 @@ exports[`Dev Server SSR > 'Full HTML document with head/body' 1`] = `
 </html>
 `;
 
+exports[`Dev Server SSR > 'Island with alias import' 1`] = `
+<script
+  type="module"
+  src="/@visle/entry"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/components/Counter.vue">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Dev Server SSR > 'Island with props' 1`] = `
 <script
   type="module"

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -106,6 +106,29 @@ exports[`Production Build SSR > 'Full HTML document with head/body' 1`] = `
 </html>
 `;
 
+exports[`Production Build SSR > 'Island with alias import' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<script
+  type="module"
+  src="/assets/custom-element-[hash].js"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/assets/Counter-[hash].js">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Production Build SSR > 'Island with props' 1`] = `
 <link
   rel="stylesheet"

--- a/test/fixtures/pages/with-island-alias.vue
+++ b/test/fixtures/pages/with-island-alias.vue
@@ -1,0 +1,10 @@
+<script setup>
+import Counter from '@/components/Counter.vue'
+</script>
+
+<template>
+  <div>
+    <h1>Page</h1>
+    <Counter v-client:load />
+  </div>
+</template>

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,6 +24,7 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'Nested island', component: 'with-nested-island' },
   { name: 'Multiple islands on the same page', component: 'with-multiple-islands' },
   { name: 'Non-ascii file name', component: 'テスト' },
+  { name: 'Island with alias import', component: 'with-island-alias' },
 ]
 
 /**
@@ -52,6 +53,9 @@ export function devRender(root: string) {
   const loader = createDevLoader({
     root,
     plugins: [visle()],
+    resolve: {
+      alias: { '@': root },
+    },
   })
 
   render.setLoader(loader)
@@ -66,6 +70,9 @@ export async function prodBuild(root: string): Promise<void> {
   const builder = await createBuilder({
     root,
     plugins: [visle()],
+    resolve: {
+      alias: { '@': root },
+    },
     logLevel: 'silent',
   })
 


### PR DESCRIPTION
## Summary

- Alias imports like `@/components/Counter.vue` in island components were resolved incorrectly as relative paths (e.g. `/Users/.../pages/@/components/Counter.vue`), breaking island detection, wrapping, and the islands build
- Updated `resolveId` hook to delegate alias/bare specifier imports to Vite's resolver via `this.resolve()` with `skipSelf: true`
- Updated `transform` hook to resolve alias import paths through Vite's resolver, with prefix unwrapping since our `resolveId` wraps `.vue` imports in virtual module prefixes

## Test plan

- [x] Added `with-island-alias.vue` fixture using `@/components/Counter.vue`
- [x] Added `resolve.alias` config to dev and prod test helpers
- [x] All 52 tests pass (dev, prod, hydration modes)
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Island components now support alias imports in development and production environments, complementing existing relative and absolute path resolution.

* **Improvements**
  * Import resolution system enhanced with parallel processing for improved island component loading efficiency.

* **Tests**
  * Added test fixtures and cases validating alias imports in island components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->