### PR TITLE
feat: add v-client:visible directive

### DIFF
--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 
-import { generateEntryTypesCode } from './generate.ts'
+import { buildIslandWrapId, generateEntryTypesCode, parseIslandWrapId } from './generate.ts'
 
 describe('generateEntryTypesCode', () => {
   test('generates module augmentation with component entries', () => {
@@ -42,5 +42,45 @@ describe('generateEntryTypesCode', () => {
     const result = generateEntryTypesCode('/project/pages', '/project', [])
 
     expect(result).toContain('export {}')
+  })
+})
+
+describe('buildIslandWrapId', () => {
+  test('builds id with load strategy', () => {
+    const id = buildIslandWrapId('load', '/path/to/Comp.vue')
+    expect(id).toBe('\0visle:island-wrap:load:/path/to/Comp.vue')
+  })
+
+  test('builds id with visible strategy', () => {
+    const id = buildIslandWrapId('visible', '/path/to/Comp.vue')
+    expect(id).toBe('\0visle:island-wrap:visible:/path/to/Comp.vue')
+  })
+})
+
+describe('parseIslandWrapId', () => {
+  test('parses load strategy id', () => {
+    const result = parseIslandWrapId('\0visle:island-wrap:load:/path/to/Comp.vue')
+    expect(result).toEqual({ strategy: 'load', filePath: '/path/to/Comp.vue' })
+  })
+
+  test('parses visible strategy id', () => {
+    const result = parseIslandWrapId('\0visle:island-wrap:visible:/path/to/Comp.vue')
+    expect(result).toEqual({ strategy: 'visible', filePath: '/path/to/Comp.vue' })
+  })
+
+  test('returns undefined for non-island-wrap id', () => {
+    const result = parseIslandWrapId('\0visle:server-wrap:/path/to/Comp.vue')
+    expect(result).toBeUndefined()
+  })
+
+  test('returns undefined for id without strategy separator', () => {
+    const result = parseIslandWrapId('\0visle:island-wrap:')
+    expect(result).toBeUndefined()
+  })
+
+  test('roundtrips with buildIslandWrapId', () => {
+    const id = buildIslandWrapId('visible', '/project/components/Counter.vue')
+    const parsed = parseIslandWrapId(id)
+    expect(parsed).toEqual({ strategy: 'visible', filePath: '/project/components/Counter.vue' })
   })
 })

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -2,6 +2,8 @@ import path from 'node:path'
 
 import { normalizePath } from 'vite'
 
+import type { ClientStrategy } from './sfc-analysis.js'
+
 export const clientVirtualEntryId = '\0@visle/client-entry'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
@@ -38,11 +40,9 @@ export const serverWrapPrefix = '\0visle:server-wrap:'
 
 export const islandWrapPrefix = '\0visle:island-wrap:'
 
-export type IslandStrategy = 'load' | 'visible'
-
 export function parseIslandWrapId(
   id: string,
-): { filePath: string; strategy: IslandStrategy } | undefined {
+): { filePath: string; strategy: ClientStrategy } | undefined {
   if (!id.startsWith(islandWrapPrefix)) {
     return undefined
   }
@@ -52,12 +52,12 @@ export function parseIslandWrapId(
     return undefined
   }
   return {
-    strategy: rest.slice(0, separatorIndex) as IslandStrategy,
+    strategy: rest.slice(0, separatorIndex) as ClientStrategy,
     filePath: rest.slice(separatorIndex + 1),
   }
 }
 
-export function buildIslandWrapId(strategy: IslandStrategy, filePath: string): string {
+export function buildIslandWrapId(strategy: ClientStrategy, filePath: string): string {
   return `${islandWrapPrefix}${strategy}:${filePath}`
 }
 
@@ -97,7 +97,7 @@ export function generateIslandWrapperCode(
   filePath: string,
   componentRelativePath: string,
   customElementEntryRelativePath: string,
-  strategy: IslandStrategy = 'load',
+  strategy: ClientStrategy = 'load',
 ): string {
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -38,6 +38,29 @@ export const serverWrapPrefix = '\0visle:server-wrap:'
 
 export const islandWrapPrefix = '\0visle:island-wrap:'
 
+export type IslandStrategy = 'load' | 'visible'
+
+export function parseIslandWrapId(
+  id: string,
+): { filePath: string; strategy: IslandStrategy } | undefined {
+  if (!id.startsWith(islandWrapPrefix)) {
+    return undefined
+  }
+  const rest = id.slice(islandWrapPrefix.length)
+  const separatorIndex = rest.indexOf(':')
+  if (separatorIndex === -1) {
+    return undefined
+  }
+  return {
+    strategy: rest.slice(0, separatorIndex) as IslandStrategy,
+    filePath: rest.slice(separatorIndex + 1),
+  }
+}
+
+export function buildIslandWrapId(strategy: IslandStrategy, filePath: string): string {
+  return `${islandWrapPrefix}${strategy}:${filePath}`
+}
+
 export function generateServerComponentCode(
   filePath: string,
   componentRelativePath: string,
@@ -74,10 +97,12 @@ export function generateIslandWrapperCode(
   filePath: string,
   componentRelativePath: string,
   customElementEntryRelativePath: string,
+  strategy: IslandStrategy = 'load',
 ): string {
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
   const normalizedEntryRelativePath = normalizePath(customElementEntryRelativePath)
+  const strategyAttr = strategy !== 'load' ? `\n      strategy: '${strategy}',` : ''
 
   return `import { defineComponent, h, useSSRContext, useAttrs, inject, provide, onServerPrefetch } from 'vue'
 import { islandSymbol } from '${symbolImportId}'
@@ -123,7 +148,7 @@ export default defineComponent({
 
     return () => h('${islandElementName}', {
       entry: clientImportId,
-      'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),
+      'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),${strategyAttr}
     }, [h(OriginalComponent, attrs, slots)])
   },
 })

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -209,6 +209,13 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
           map = new Map()
           islandImportMap.set(fileName, map)
         }
+        const existing = map.get(resolvedPath)
+        if (existing && existing !== strategy) {
+          this.error(
+            `Conflicting v-client strategies for "${tag}" in ${fileName}: ` +
+              `"${existing}" and "${strategy}" cannot be used on the same component.`,
+          )
+        }
         map.set(resolvedPath, strategy)
       }
     },

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -7,13 +7,12 @@ import {
   buildIslandWrapId,
   generateIslandWrapperCode,
   generateServerComponentCode,
-  type IslandStrategy,
   islandWrapPrefix,
   parseIslandWrapId,
   serverWrapPrefix,
 } from '../generate.js'
 import { customElementEntryPath, parseId } from '../paths.js'
-import { buildImportMap, findVClientElements } from '../sfc-analysis.js'
+import { buildImportMap, type ClientStrategy, findVClientElements } from '../sfc-analysis.js'
 
 interface ServerTransformPluginResult {
   plugin: Plugin
@@ -34,7 +33,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
    * Map from importer file path → (absolute component path → strategy).
    * Populated by the transform hook, consumed by resolveId.
    */
-  const islandImportMap = new Map<string, Map<string, IslandStrategy>>()
+  const islandImportMap = new Map<string, Map<string, ClientStrategy>>()
 
   let viteConfig: ResolvedConfig
 

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -4,9 +4,12 @@ import type { Plugin, ResolvedConfig } from 'vite'
 import { parse } from 'vue/compiler-sfc'
 
 import {
+  buildIslandWrapId,
   generateIslandWrapperCode,
   generateServerComponentCode,
+  type IslandStrategy,
   islandWrapPrefix,
+  parseIslandWrapId,
   serverWrapPrefix,
 } from '../generate.js'
 import { customElementEntryPath, parseId } from '../paths.js'
@@ -28,11 +31,10 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
   const islandPaths = new Set<string>()
 
   /**
-   * Map from importer file path → set of absolute component paths
-   * that should be resolved as island wrappers.
+   * Map from importer file path → (absolute component path → strategy).
    * Populated by the transform hook, consumed by resolveId.
    */
-  const islandImportMap = new Map<string, Set<string>>()
+  const islandImportMap = new Map<string, Map<string, IslandStrategy>>()
 
   let viteConfig: ResolvedConfig
 
@@ -73,8 +75,11 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
           // Check if this import was marked as an island by the transform hook.
           // The importer may include a query (e.g. ?vue&type=script), so strip it.
           const importerPath = importer ? parseId(importer).fileName : undefined
-          if (importerPath && islandImportMap.get(importerPath)?.has(absolutePath)) {
-            return islandWrapPrefix + absolutePath
+          const strategy = importerPath
+            ? islandImportMap.get(importerPath)?.get(absolutePath)
+            : undefined
+          if (strategy) {
+            return buildIslandWrapId(strategy, absolutePath)
           }
 
           return serverWrapPrefix + absolutePath
@@ -92,8 +97,9 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         return generateServerComponentCode(filePath, componentRelativePath)
       }
 
-      if (id.startsWith(islandWrapPrefix)) {
-        const filePath = id.slice(islandWrapPrefix.length)
+      const islandWrap = parseIslandWrapId(id)
+      if (islandWrap) {
+        const { filePath, strategy } = islandWrap
         const componentRelativePath = path.relative(viteConfig.root, filePath)
         const customElementEntryRelativePath = path.relative(
           viteConfig.root,
@@ -103,6 +109,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
           filePath,
           componentRelativePath,
           customElementEntryRelativePath,
+          strategy,
         )
       }
     },
@@ -128,7 +135,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       // Build tag-name-to-import-source map from <script setup>
       const importMap = buildImportMap(descriptor, id)
 
-      // Find elements with v-client:load
+      // Find elements with v-client directives
       const matches = findVClientElements(descriptor.template.ast.children)
 
       if (matches.length === 0) {
@@ -137,11 +144,12 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
       // Resolve alias import sources in parallel
       const resolveResults = await Promise.all(
-        matches.map(async (node) => {
+        matches.map(async ({ element: node, strategy }) => {
           const importInfo = importMap.get(node.tag)
           if (!importInfo) {
             return {
               tag: node.tag,
+              strategy,
               importInfo: undefined,
               resolvedPath: undefined,
             }
@@ -158,25 +166,29 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
             const resolvedId = resolved.id
             if (resolvedId.startsWith(serverWrapPrefix)) {
               resolvedPath = resolvedId.slice(serverWrapPrefix.length)
-            } else if (resolvedId.startsWith(islandWrapPrefix)) {
-              resolvedPath = resolvedId.slice(islandWrapPrefix.length)
             } else {
-              resolvedPath = resolvedId
+              const islandWrap = parseIslandWrapId(resolvedId)
+              if (islandWrap) {
+                resolvedPath = islandWrap.filePath
+              } else {
+                resolvedPath = resolvedId
+              }
             }
           }
 
           return {
             tag: node.tag,
+            strategy,
             importInfo,
             resolvedPath,
           }
         }),
       )
 
-      for (const { tag, importInfo, resolvedPath } of resolveResults) {
+      for (const { tag, strategy, importInfo, resolvedPath } of resolveResults) {
         if (!importInfo) {
           this.warn(
-            `v-client:load on "${tag}" is not supported. ` +
+            `v-client:${strategy} on "${tag}" is not supported. ` +
               'Only statically imported Vue components are supported.',
           )
           continue
@@ -184,7 +196,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
         if (!resolvedPath) {
           this.warn(
-            `Could not resolve import "${importInfo.source}" for v-client:load component "${tag}" in ${fileName}`,
+            `Could not resolve import "${importInfo.source}" for v-client:${strategy} component "${tag}" in ${fileName}`,
           )
           continue
         }
@@ -193,12 +205,12 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
         // Record in the island import map so resolveId can redirect this import
         // to the island wrapper virtual module
-        let set = islandImportMap.get(fileName)
-        if (!set) {
-          set = new Set()
-          islandImportMap.set(fileName, set)
+        let map = islandImportMap.get(fileName)
+        if (!map) {
+          map = new Map()
+          islandImportMap.set(fileName, map)
         }
-        set.add(resolvedPath)
+        map.set(resolvedPath, strategy)
       }
     },
   }

--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -289,7 +289,16 @@ describe('findVClientElements', () => {
     const children = parseTemplate('<Counter v-client:load />')
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0]!.tag).toBe('Counter')
+    expect(results[0]!.element.tag).toBe('Counter')
+    expect(results[0]!.strategy).toBe('load')
+  })
+
+  test('finds element with v-client:visible', () => {
+    const children = parseTemplate('<Counter v-client:visible />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0]!.element.tag).toBe('Counter')
+    expect(results[0]!.strategy).toBe('visible')
   })
 
   test('finds multiple elements with v-client:load', () => {
@@ -299,10 +308,23 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(2)
-    expect(results.map((r) => r.tag)).toEqual(['Counter', 'Header'])
+    expect(results.map((r) => r.element.tag)).toEqual(['Counter', 'Header'])
   })
 
-  test('ignores elements without v-client:load', () => {
+  test('finds elements with mixed strategies', () => {
+    const children = parseTemplate(`
+      <Counter v-client:load />
+      <Header v-client:visible />
+    `)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(2)
+    expect(results[0]!.element.tag).toBe('Counter')
+    expect(results[0]!.strategy).toBe('load')
+    expect(results[1]!.element.tag).toBe('Header')
+    expect(results[1]!.strategy).toBe('visible')
+  })
+
+  test('ignores elements without v-client directive', () => {
     const children = parseTemplate(`
       <Counter />
       <Header v-client:load />
@@ -310,7 +332,7 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0]!.tag).toBe('Header')
+    expect(results[0]!.element.tag).toBe('Header')
   })
 
   test('finds nested elements with v-client:load', () => {
@@ -323,7 +345,7 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0]!.tag).toBe('Counter')
+    expect(results[0]!.element.tag).toBe('Counter')
   })
 
   test('finds deeply nested and top-level elements', () => {
@@ -335,10 +357,10 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(2)
-    expect(results.map((r) => r.tag)).toEqual(['Header', 'Counter'])
+    expect(results.map((r) => r.element.tag)).toEqual(['Header', 'Counter'])
   })
 
-  test('returns empty array when no v-client:load elements', () => {
+  test('returns empty array when no v-client elements', () => {
     const children = parseTemplate(`
       <div>
         <Counter />
@@ -362,13 +384,19 @@ describe('findVClientElements', () => {
     `)
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0]!.tag).toBe('Header')
+    expect(results[0]!.element.tag).toBe('Header')
+  })
+
+  test('ignores v-client with unsupported argument', () => {
+    const children = parseTemplate('<Counter v-client:unknown />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(0)
   })
 
   test('finds v-client:load on native HTML elements', () => {
     const children = parseTemplate('<div v-client:load />')
     const results = findVClientElements(children)
     expect(results).toHaveLength(1)
-    expect(results[0]!.tag).toBe('div')
+    expect(results[0]!.element.tag).toBe('div')
   })
 })

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -127,27 +127,39 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
   return map
 }
 
+export type ClientStrategy = 'load' | 'visible'
+
+const clientStrategies: Set<string> = new Set<ClientStrategy>(['load', 'visible'])
+
+export interface VClientMatch {
+  element: ElementNode
+  strategy: ClientStrategy
+}
+
 /**
- * Recursively finds elements with v-client:load directive.
+ * Recursively finds elements with v-client directive (e.g. v-client:load, v-client:visible).
  */
-export function findVClientElements(children: TemplateChildNode[]): ElementNode[] {
-  const results: ElementNode[] = []
+export function findVClientElements(children: TemplateChildNode[]): VClientMatch[] {
+  const results: VClientMatch[] = []
 
   for (const child of children) {
     if (child.type !== NodeTypes.ELEMENT) {
       continue
     }
 
-    const hasVClient = child.props.some(
-      (prop) =>
+    for (const prop of child.props) {
+      if (
         prop.type === NodeTypes.DIRECTIVE &&
         prop.name === 'client' &&
         prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
-        prop.arg.content === 'load',
-    )
-
-    if (hasVClient) {
-      results.push(child)
+        clientStrategies.has(prop.arg.content)
+      ) {
+        results.push({
+          element: child,
+          strategy: prop.arg.content as ClientStrategy,
+        })
+        break
+      }
     }
 
     if (child.children.length > 0) {

--- a/src/client/custom-element.test.ts
+++ b/src/client/custom-element.test.ts
@@ -15,6 +15,28 @@ vi.mock('./load-module.ts', () => ({
   loadModule: vi.fn(() => Promise.resolve({ default: { name: 'TestComponent' } })),
 }))
 
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
+  static lastCallback: IntersectionObserverCallback
+
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  root = null
+  rootMargin = ''
+  thresholds = [0]
+  takeRecords = vi.fn(() => [] as IntersectionObserverEntry[])
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    public options?: IntersectionObserverInit,
+  ) {
+    MockIntersectionObserver.instances.push(this)
+    MockIntersectionObserver.lastCallback = callback
+  }
+}
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+
 function createIsland(attrs?: Record<string, string>): VueIsland {
   const el = new VueIsland()
   if (attrs) {
@@ -32,6 +54,7 @@ function flushMicrotasks(): Promise<void> {
 describe('VueIsland custom element', () => {
   beforeEach(() => {
     vi.mocked(createSSRApp).mockClear()
+    MockIntersectionObserver.instances = []
     document.body.innerHTML = ''
   })
 
@@ -115,6 +138,66 @@ describe('VueIsland custom element', () => {
 
       expect(firstApp.unmount).toHaveBeenCalled()
       expect(createSSRApp).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('strategy=visible', () => {
+    test('defers hydration until element is intersecting', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      // Should not mount immediately
+      expect(createSSRApp).not.toHaveBeenCalled()
+
+      // Simulate intersection
+      const observer = MockIntersectionObserver.instances[0]!
+      MockIntersectionObserver.lastCallback(
+        [{ isIntersecting: true, target: el } as unknown as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      )
+      await flushMicrotasks()
+
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('does not hydrate on non-intersecting entry', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      const observer = MockIntersectionObserver.instances[0]!
+      MockIntersectionObserver.lastCallback(
+        [{ isIntersecting: false, target: el } as unknown as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      )
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+    })
+
+    test('passes root-margin option to IntersectionObserver', async () => {
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'visible',
+        'root-margin': '200px',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      const observer = MockIntersectionObserver.instances[0]!
+      expect(observer.options).toEqual({ rootMargin: '200px' })
+    })
+
+    test('disconnects observer on disconnect', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      const observer = MockIntersectionObserver.instances[0]!
+      document.body.removeChild(el)
+
+      expect(observer.disconnect).toHaveBeenCalled()
     })
   })
 

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -12,6 +12,8 @@ export class VueIsland extends HTMLElement {
    */
   #connectToken = 0
 
+  #observer: IntersectionObserver | null = null
+
   constructor() {
     super()
 
@@ -32,6 +34,28 @@ export class VueIsland extends HTMLElement {
       this.#app = null
     }
 
+    const strategy = this.getAttribute('strategy')
+
+    if (strategy === 'visible') {
+      this.#observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries.find((e) => e.isIntersecting)
+          if (entry) {
+            this.#observer?.disconnect()
+            this.#observer = null
+            this.#hydrate(token)
+          }
+        },
+        { rootMargin: this.getAttribute('root-margin') ?? '0px' },
+      )
+      this.#observer.observe(this)
+      return
+    }
+
+    await this.#hydrate(token)
+  }
+
+  async #hydrate(token: number): Promise<void> {
     const entry = this.getAttribute('entry')
     if (!entry) {
       return
@@ -54,6 +78,8 @@ export class VueIsland extends HTMLElement {
 
   disconnectedCallback(): void {
     this.#connectToken++
+    this.#observer?.disconnect()
+    this.#observer = null
     this.#app?.unmount()
     this.#app = null
   }

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -37,6 +37,7 @@ export class VueIsland extends HTMLElement {
     const strategy = this.getAttribute('strategy')
 
     if (strategy === 'visible') {
+      const rootMargin = this.getAttribute('root-margin') ?? undefined
       this.#observer = new IntersectionObserver(
         (entries) => {
           const entry = entries.find((e) => e.isIntersecting)
@@ -46,7 +47,7 @@ export class VueIsland extends HTMLElement {
             this.#hydrate(token)
           }
         },
-        { rootMargin: this.getAttribute('root-margin') ?? '0px' },
+        { rootMargin },
       )
       this.#observer.observe(this)
       return


### PR DESCRIPTION
[Posted by an agent]

Closes #72

## Summary
- Extended `findVClientElements()` in `src/build/sfc-analysis.ts` to recognize both `load` and `visible` arguments, returning a `VClientMatch` object with `element` and `strategy` fields
- Added `parseIslandWrapId()` / `buildIslandWrapId()` helpers in `src/build/generate.ts` to encode the strategy in the island wrapper virtual module ID (e.g. `\0visle:island-wrap:visible:/path/to/Comp.vue`)
- Updated `generateIslandWrapperCode()` to emit a `strategy` attribute on the `<vue-island>` element when the strategy is not `load`
- Updated `src/build/plugins/server-transform.ts` to thread the strategy through the island import map and virtual module resolution
- In `src/client/custom-element.ts`, the `connectedCallback()` now checks for `strategy="visible"` and uses `IntersectionObserver` to defer hydration until the element enters the viewport
- Supports an optional `root-margin` attribute for pre-loading (passed to `IntersectionObserver` as `rootMargin`)
- Added tests for the `visible` strategy in both `sfc-analysis.test.ts` and `custom-element.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Islands now support selectable hydration strategies: immediate load or visibility-based (hydrates when an element becomes visible). Visibility-based hydration respects a configurable root-margin.
  * Strategy information is propagated through the build/runtime so directives with a strategy are handled consistently.

* **Tests**
  * Added comprehensive tests covering visibility-based hydration, mixed strategies, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->