### PR TITLE
refactor: extract generated component code into real server modules

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -2,5 +2,10 @@
   "name": "@ktsn/visle",
   "version": "0.0.0",
   "license": "MIT",
-  "exports": "./src/server/index.ts"
+  "exports": {
+    ".": "./src/server/index.ts",
+    "./internal": "./src/server/internal.ts",
+    "./build": "./src/build/index.ts",
+    "./dev": "./src/server/dev.ts"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/server/index.js",
+    "./internal": "./dist/server/internal.js",
     "./build": "./dist/build/index.js",
     "./dev": "./dist/server/dev.js"
   },

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -41,10 +41,13 @@ export function generateServerComponentCode(
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
 
+  const serializedFilePath = JSON.stringify(normalizedFilePath)
+  const serializedRelativePath = JSON.stringify(normalizedRelativePath)
+
   return `import { createServerComponent } from 'visle/internal'
-import OriginalComponent from '${normalizedFilePath}'
-export * from '${normalizedFilePath}'
-export default createServerComponent('${normalizedRelativePath}', OriginalComponent)
+import OriginalComponent from ${serializedFilePath}
+export * from ${serializedFilePath}
+export default createServerComponent(${serializedRelativePath}, OriginalComponent)
 `
 }
 
@@ -57,10 +60,14 @@ export function generateIslandWrapperCode(
   const normalizedRelativePath = normalizePath(componentRelativePath)
   const normalizedEntryRelativePath = normalizePath(customElementEntryRelativePath)
 
+  const serializedFilePath = JSON.stringify(normalizedFilePath)
+  const serializedRelativePath = JSON.stringify(normalizedRelativePath)
+  const serializedEntryRelativePath = JSON.stringify(normalizedEntryRelativePath)
+
   return `import { createIslandWrapper } from 'visle/internal'
-import OriginalComponent from '${normalizedFilePath}'
-export * from '${normalizedFilePath}'
-export default createIslandWrapper('${normalizedRelativePath}', '${normalizedEntryRelativePath}', OriginalComponent)
+import OriginalComponent from ${serializedFilePath}
+export * from ${serializedFilePath}
+export default createIslandWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, OriginalComponent)
 `
 }
 

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -6,9 +6,9 @@ export const clientVirtualEntryId = '\0@visle/client-entry'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
 
-export const symbolImportId = '\0@visle/symbols'
+export const serverWrapPrefix = '\0visle:server-wrap:'
 
-export const symbolCode = `export const islandSymbol = Symbol('@visle/island')`
+export const islandWrapPrefix = '\0visle:island-wrap:'
 
 export const islandElementName = 'vue-island'
 
@@ -34,10 +34,6 @@ export function generateServerVirtualEntryCode(entryDir: string, componentIds: s
   return `${imports}\nexport default {\n${entries}\n}`
 }
 
-export const serverWrapPrefix = '\0visle:server-wrap:'
-
-export const islandWrapPrefix = '\0visle:island-wrap:'
-
 export function generateServerComponentCode(
   filePath: string,
   componentRelativePath: string,
@@ -45,28 +41,10 @@ export function generateServerComponentCode(
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
 
-  return `import { defineComponent, h, useSSRContext, onServerPrefetch } from 'vue'
+  return `import { createServerComponent } from 'visle/internal'
 import OriginalComponent from '${normalizedFilePath}'
-
 export * from '${normalizedFilePath}'
-
-export default defineComponent({
-  setup(_props, { slots }) {
-    const context = useSSRContext()
-    const manifest = context.manifest
-
-    onServerPrefetch(async () => {
-      const cssIds = await manifest.getDependingClientCssIds('${normalizedRelativePath}')
-
-      context.loadCss ??= new Set()
-      for (const cssId of cssIds) {
-        context.loadCss.add(cssId)
-      }
-    })
-
-    return () => h(OriginalComponent, null, slots)
-  },
-})
+export default createServerComponent('${normalizedRelativePath}', OriginalComponent)
 `
 }
 
@@ -79,54 +57,10 @@ export function generateIslandWrapperCode(
   const normalizedRelativePath = normalizePath(componentRelativePath)
   const normalizedEntryRelativePath = normalizePath(customElementEntryRelativePath)
 
-  return `import { defineComponent, h, useSSRContext, useAttrs, inject, provide, onServerPrefetch } from 'vue'
-import { islandSymbol } from '${symbolImportId}'
+  return `import { createIslandWrapper } from 'visle/internal'
 import OriginalComponent from '${normalizedFilePath}'
-
 export * from '${normalizedFilePath}'
-
-export default defineComponent({
-  inheritAttrs: false,
-  setup(_props, { slots }) {
-    const inIsland = inject(islandSymbol, false)
-    provide(islandSymbol, true)
-
-    const context = useSSRContext()
-    const attrs = useAttrs()
-    const manifest = context.manifest
-
-    let clientImportId = ''
-
-    onServerPrefetch(async () => {
-      const [resolvedClientImportId, entryImportId, cssIds] = await Promise.all([
-        manifest.getClientImportId('${normalizedRelativePath}'),
-        manifest.getClientImportId('${normalizedEntryRelativePath}'),
-        manifest.getDependingClientCssIds('${normalizedRelativePath}'),
-      ])
-
-      clientImportId = resolvedClientImportId
-
-      context.loadJs ??= new Set()
-      context.loadJs.add(entryImportId)
-
-      context.loadCss ??= new Set()
-      for (const cssId of cssIds) {
-        context.loadCss.add(cssId)
-      }
-    })
-
-    if (inIsland) {
-      return () => h(OriginalComponent, attrs, slots)
-    }
-
-    const isEmptyProps = Object.keys(attrs).length === 0
-
-    return () => h('${islandElementName}', {
-      entry: clientImportId,
-      'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),
-    }, [h(OriginalComponent, attrs, slots)])
-  },
-})
+export default createIslandWrapper('${normalizedRelativePath}', '${normalizedEntryRelativePath}', OriginalComponent)
 `
 }
 

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -34,20 +34,17 @@ export function generateServerVirtualEntryCode(entryDir: string, componentIds: s
   return `${imports}\nexport default {\n${entries}\n}`
 }
 
-export function generateServerComponentCode(
-  filePath: string,
-  componentRelativePath: string,
-): string {
+export function generateServerWrapperCode(filePath: string, componentRelativePath: string): string {
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
 
   const serializedFilePath = JSON.stringify(normalizedFilePath)
   const serializedRelativePath = JSON.stringify(normalizedRelativePath)
 
-  return `import { createServerComponent } from 'visle/internal'
+  return `import { createServerWrapper } from 'visle/internal'
 import OriginalComponent from ${serializedFilePath}
 export * from ${serializedFilePath}
-export default createServerComponent(${serializedRelativePath}, OriginalComponent)
+export default createServerWrapper(${serializedRelativePath}, OriginalComponent)
 `
 }
 

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -5,7 +5,7 @@ import { parse } from 'vue/compiler-sfc'
 
 import {
   generateIslandWrapperCode,
-  generateServerComponentCode,
+  generateServerWrapperCode,
   islandWrapPrefix,
   serverWrapPrefix,
 } from '../generate.js'
@@ -89,7 +89,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       if (id.startsWith(serverWrapPrefix)) {
         const filePath = id.slice(serverWrapPrefix.length)
         const componentRelativePath = path.relative(viteConfig.root, filePath)
-        return generateServerComponentCode(filePath, componentRelativePath)
+        return generateServerWrapperCode(filePath, componentRelativePath)
       }
 
       if (id.startsWith(islandWrapPrefix)) {

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -9,8 +9,6 @@ import {
   generateServerVirtualEntryCode,
   clientVirtualEntryId,
   serverVirtualEntryId,
-  symbolCode,
-  symbolImportId,
 } from '../generate.js'
 import {
   customElementEntryPath,
@@ -37,7 +35,6 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
         clientVirtualEntryId,
         serverVirtualEntryId,
         virtualCustomElementEntryPath,
-        symbolImportId,
       ]
 
       if (virtuals.includes(id)) {
@@ -46,10 +43,6 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
     },
 
     load(id) {
-      if (id === symbolImportId) {
-        return symbolCode
-      }
-
       if (id === serverVirtualEntryId) {
         return generateServerVirtualEntryCode(entryRoot, resolveServerComponentIds(entryRoot))
       }

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -31,11 +31,7 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
     },
 
     resolveId(id) {
-      const virtuals = [
-        clientVirtualEntryId,
-        serverVirtualEntryId,
-        virtualCustomElementEntryPath,
-      ]
+      const virtuals = [clientVirtualEntryId, serverVirtualEntryId, virtualCustomElementEntryPath]
 
       if (virtuals.includes(id)) {
         return id

--- a/src/server/internal.ts
+++ b/src/server/internal.ts
@@ -1,0 +1,3 @@
+export { islandSymbol } from './symbol.js'
+export { createServerComponent } from './server-component.js'
+export { createIslandWrapper } from './island-wrapper.js'

--- a/src/server/internal.ts
+++ b/src/server/internal.ts
@@ -1,3 +1,3 @@
 export { islandSymbol } from './symbol.js'
-export { createServerComponent } from './server-component.js'
+export { createServerWrapper } from './server-wrapper.js'
 export { createIslandWrapper } from './island-wrapper.js'

--- a/src/server/island-wrapper.ts
+++ b/src/server/island-wrapper.ts
@@ -1,0 +1,61 @@
+import type { Component } from 'vue'
+import { defineComponent, h, useSSRContext, useAttrs, inject, provide, onServerPrefetch } from 'vue'
+
+import { RenderContext } from './render.js'
+import { islandSymbol } from './symbol.js'
+
+const islandElementName = 'vue-island'
+
+export function createIslandWrapper(
+  normalizedRelativePath: string,
+  normalizedEntryRelativePath: string,
+  OriginalComponent: Component,
+) {
+  return defineComponent({
+    inheritAttrs: false,
+    setup(_props, { slots }) {
+      const inIsland = inject(islandSymbol, false)
+      provide(islandSymbol, true)
+
+      const context: RenderContext = useSSRContext()!
+      const attrs = useAttrs()
+      const manifest = context.manifest!
+
+      let clientImportId = ''
+
+      onServerPrefetch(async () => {
+        const [resolvedClientImportId, entryImportId, cssIds] = await Promise.all([
+          manifest.getClientImportId(normalizedRelativePath),
+          manifest.getClientImportId(normalizedEntryRelativePath),
+          manifest.getDependingClientCssIds(normalizedRelativePath),
+        ])
+
+        clientImportId = resolvedClientImportId
+
+        context.loadJs ??= new Set()
+        context.loadJs.add(entryImportId)
+
+        context.loadCss ??= new Set()
+        for (const cssId of cssIds) {
+          context.loadCss.add(cssId)
+        }
+      })
+
+      if (inIsland) {
+        return () => h(OriginalComponent, attrs, slots)
+      }
+
+      const isEmptyProps = Object.keys(attrs).length === 0
+
+      return () =>
+        h(
+          islandElementName,
+          {
+            entry: clientImportId,
+            'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),
+          },
+          [h(OriginalComponent, attrs, slots)],
+        )
+    },
+  })
+}

--- a/src/server/island-wrapper.ts
+++ b/src/server/island-wrapper.ts
@@ -1,7 +1,7 @@
 import type { Component } from 'vue'
 import { defineComponent, h, useSSRContext, useAttrs, inject, provide, onServerPrefetch } from 'vue'
 
-import { RenderContext } from './render.js'
+import type { RenderContext } from './render.js'
 import { islandSymbol } from './symbol.js'
 
 const islandElementName = 'vue-island'

--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { describe, test, expect, beforeEach } from 'vitest'
 
@@ -153,6 +154,14 @@ describe('createRender', () => {
         createDevLoader({
           root,
           plugins: [visle()],
+          resolve: {
+            alias: {
+              'visle/internal': path.resolve(
+                path.dirname(fileURLToPath(import.meta.url)),
+                'internal.ts',
+              ),
+            },
+          },
         }),
       )
 

--- a/src/server/server-component.ts
+++ b/src/server/server-component.ts
@@ -1,0 +1,27 @@
+import type { Component } from 'vue'
+import { defineComponent, h, useSSRContext, onServerPrefetch } from 'vue'
+
+import { RenderContext } from './render.js'
+
+export function createServerComponent(
+  normalizedRelativePath: string,
+  OriginalComponent: Component,
+) {
+  return defineComponent({
+    setup(_props, { slots }) {
+      const context: RenderContext = useSSRContext()!
+      const manifest = context.manifest!
+
+      onServerPrefetch(async () => {
+        const cssIds = await manifest.getDependingClientCssIds(normalizedRelativePath)
+
+        context.loadCss ??= new Set()
+        for (const cssId of cssIds) {
+          context.loadCss.add(cssId)
+        }
+      })
+
+      return () => h(OriginalComponent, null, slots)
+    },
+  })
+}

--- a/src/server/server-component.ts
+++ b/src/server/server-component.ts
@@ -1,7 +1,7 @@
 import type { Component } from 'vue'
 import { defineComponent, h, useSSRContext, onServerPrefetch } from 'vue'
 
-import { RenderContext } from './render.js'
+import type { RenderContext } from './render.js'
 
 export function createServerComponent(
   normalizedRelativePath: string,

--- a/src/server/server-wrapper.ts
+++ b/src/server/server-wrapper.ts
@@ -3,10 +3,7 @@ import { defineComponent, h, useSSRContext, onServerPrefetch } from 'vue'
 
 import type { RenderContext } from './render.js'
 
-export function createServerComponent(
-  normalizedRelativePath: string,
-  OriginalComponent: Component,
-) {
+export function createServerWrapper(normalizedRelativePath: string, OriginalComponent: Component) {
   return defineComponent({
     setup(_props, { slots }) {
       const context: RenderContext = useSSRContext()!

--- a/src/server/symbol.ts
+++ b/src/server/symbol.ts
@@ -1,0 +1,1 @@
+export const islandSymbol = Symbol('@visle/island')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,6 +10,7 @@ import { createRender } from '../src/server/render.ts'
 
 const tmpDir = path.resolve('test/__generated__/integration')
 const fixturesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures')
+const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src')
 
 export const renderCases: { name: string; component: string; props?: Record<string, unknown> }[] = [
   { name: 'Static component rendering', component: 'static' },
@@ -59,7 +60,10 @@ export function devRender(root: string) {
     root,
     plugins: [visle()],
     resolve: {
-      alias: { '@': root },
+      alias: {
+        '@': root,
+        'visle/internal': path.join(srcDir, 'server/internal.ts'),
+      },
     },
   })
 
@@ -76,7 +80,10 @@ export async function prodBuild(root: string): Promise<void> {
     root,
     plugins: [visle()],
     resolve: {
-      alias: { '@': root },
+      alias: {
+        '@': root,
+        'visle/internal': path.join(srcDir, 'server/internal.ts'),
+      },
     },
     logLevel: 'silent',
   })


### PR DESCRIPTION
Move runtime logic from template strings in generate.ts into real TypeScript modules (server-component.ts, island-wrapper.ts, symbol.ts) exported via visle/internal. Generated code now becomes thin wrappers calling these functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new "./internal" export entry providing access to internal utilities
  * Exposed new public API bindings for advanced component wrapping and island context management

* **Refactor**
  * Updated internal build system naming conventions for improved consistency
  * Refactored server-side component code generation approach
<!-- end of auto-generated comment: release notes by coderabbit.ai -->