### PR TITLE
fix: resolve /@visle/entry to actual file path in dev mode

### DIFF
--- a/src/build/plugins/virtual-file.test.ts
+++ b/src/build/plugins/virtual-file.test.ts
@@ -23,9 +23,7 @@ describe('virtualFilePlugin', () => {
       logLevel: 'silent',
     })
 
-    const result = await server.environments.client.transformRequest(
-      virtualCustomElementEntryPath,
-    )
+    const result = await server.environments.client.transformRequest(virtualCustomElementEntryPath)
 
     expect(result).not.toBeNull()
     expect(result!.code).toContain('vue-island')

--- a/src/build/plugins/virtual-file.test.ts
+++ b/src/build/plugins/virtual-file.test.ts
@@ -1,0 +1,33 @@
+import { createServer, type ViteDevServer } from 'vite'
+import { describe, test, expect, afterEach } from 'vitest'
+
+import { defaultConfig } from '../config.ts'
+import { virtualCustomElementEntryPath } from '../paths.ts'
+import { virtualFilePlugin } from './virtual-file.ts'
+
+describe('virtualFilePlugin', () => {
+  let server: ViteDevServer | undefined
+
+  afterEach(async () => {
+    await server?.close()
+    server = undefined
+  })
+
+  test('custom element entry is transformable in client environment', async () => {
+    server = await createServer({
+      configFile: false,
+      plugins: [virtualFilePlugin(defaultConfig)],
+      appType: 'custom',
+      server: { middlewareMode: true },
+      optimizeDeps: { noDiscovery: true },
+      logLevel: 'silent',
+    })
+
+    const result = await server.environments.client.transformRequest(
+      virtualCustomElementEntryPath,
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.code).toContain('vue-island')
+  })
+})

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { Plugin } from 'vite'
@@ -31,7 +30,11 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
     },
 
     resolveId(id) {
-      const virtuals = [clientVirtualEntryId, serverVirtualEntryId, virtualCustomElementEntryPath]
+      if (id === virtualCustomElementEntryPath) {
+        return customElementEntryPath
+      }
+
+      const virtuals = [clientVirtualEntryId, serverVirtualEntryId, ]
 
       if (virtuals.includes(id)) {
         return id
@@ -45,10 +48,6 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
 
       if (id === clientVirtualEntryId) {
         return generateClientVirtualEntryCode(resolveServerComponentIds(entryRoot))
-      }
-
-      if (id === virtualCustomElementEntryPath) {
-        return readFile(customElementEntryPath, 'utf-8')
       }
 
       return null

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -34,7 +34,7 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
         return customElementEntryPath
       }
 
-      const virtuals = [clientVirtualEntryId, serverVirtualEntryId, ]
+      const virtuals = [clientVirtualEntryId, serverVirtualEntryId]
 
       if (virtuals.includes(id)) {
         return id


### PR DESCRIPTION
## Summary

- The virtual file plugin was reading `custom-element.js` via `readFile` and serving its raw content from the virtual path `/@visle/entry`. Since `custom-element.ts` imports `./load-module.js` with a relative path, Vite could not resolve that import from the virtual location, causing a 404.
- Fix by resolving `/@visle/entry` directly to `customElementEntryPath` in `resolveId`, letting Vite load the real file and resolve its imports correctly.

## Test plan

- [x] Added `virtual-file.test.ts` that creates a Vite dev server and verifies `/@visle/entry` is transformable in the client environment
- [x] Test fails before the fix (`Failed to resolve import "./load-module.js"`) and passes after
- [x] All 120 tests pass
- [x] Manually verified with ec-site example: `/@visle/entry` returns 200