### PR TITLE
feat: support named imports for island components

### DIFF
--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -44,22 +44,25 @@ export function generateComponentWrapperCode(
   const serializedRelativePath = JSON.stringify(normalizedRelativePath)
   const serializedEntryRelativePath = JSON.stringify(normalizedEntryRelativePath)
 
-  const specifiers = importedNames.map((name, i) => `${name} as __visle_${i}`).join(', ')
-  const imports = `import { ${specifiers} } from ${serializedFilePath}`
+  const lines = [
+    `import { createComponentWrapper } from 'visle/internal'`,
+    `export * from ${serializedFilePath}`,
+  ]
 
-  const exports = importedNames
-    .map((name, i) =>
-      name === 'default'
-        ? `export default createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`
-        : `export const ${name} = createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`,
-    )
-    .join('\n')
+  if (importedNames.length > 0) {
+    const specifiers = importedNames.map((name, i) => `${name} as __visle_${i}`).join(', ')
+    lines.push(`import { ${specifiers} } from ${serializedFilePath}`)
 
-  return `import { createComponentWrapper } from 'visle/internal'
-export * from ${serializedFilePath}
-${imports}
-${exports}
-`
+    for (const [i, name] of importedNames.entries()) {
+      lines.push(
+        name === 'default'
+          ? `export default createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`
+          : `export const ${name} = createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`,
+      )
+    }
+  }
+
+  return lines.join('\n') + '\n'
 }
 
 export function generateEntryTypesCode(

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -44,13 +44,9 @@ export function generateComponentWrapperCode(
   const serializedRelativePath = JSON.stringify(normalizedRelativePath)
   const serializedEntryRelativePath = JSON.stringify(normalizedEntryRelativePath)
 
-  const imports = importedNames
-    .map((name, i) =>
-      name === 'default'
-        ? `import __visle_${i} from ${serializedFilePath}`
-        : `import { ${name} as __visle_${i} } from ${serializedFilePath}`,
-    )
-    .join('\n')
+  const specifiers = importedNames.map((name, i) => `${name} as __visle_${i}`).join(', ')
+  const imports = `import { ${specifiers} } from ${serializedFilePath}`
+
   const exports = importedNames
     .map((name, i) =>
       name === 'default'

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -34,6 +34,7 @@ export function generateComponentWrapperCode(
   filePath: string,
   componentRelativePath: string,
   customElementEntryRelativePath: string,
+  importedNames: string[],
 ): string {
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
@@ -43,10 +44,25 @@ export function generateComponentWrapperCode(
   const serializedRelativePath = JSON.stringify(normalizedRelativePath)
   const serializedEntryRelativePath = JSON.stringify(normalizedEntryRelativePath)
 
+  const imports = importedNames
+    .map((name, i) =>
+      name === 'default'
+        ? `import __visle_${i} from ${serializedFilePath}`
+        : `import { ${name} as __visle_${i} } from ${serializedFilePath}`,
+    )
+    .join('\n')
+  const exports = importedNames
+    .map((name, i) =>
+      name === 'default'
+        ? `export default createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`
+        : `export const ${name} = createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`,
+    )
+    .join('\n')
+
   return `import { createComponentWrapper } from 'visle/internal'
-import OriginalComponent from ${serializedFilePath}
 export * from ${serializedFilePath}
-export default createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, OriginalComponent)
+${imports}
+${exports}
 `
 }
 

--- a/src/build/paths.test.ts
+++ b/src/build/paths.test.ts
@@ -43,4 +43,12 @@ describe('parseId', () => {
       prefix: undefined,
     })
   })
+
+  test('filters empty name segments', () => {
+    expect(parseId('/foo/bar.vue?names=A,,B')).toEqual({
+      fileName: '/foo/bar.vue',
+      query: { names: ['A', 'B'] },
+      prefix: undefined,
+    })
+  })
 })

--- a/src/build/paths.test.ts
+++ b/src/build/paths.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { componentWrapPrefix } from './generate.js'
+import { parseId } from './paths.js'
+
+describe('parseId', () => {
+  test('plain file path', () => {
+    expect(parseId('/foo/bar.vue')).toEqual({
+      fileName: '/foo/bar.vue',
+      query: {},
+      prefix: undefined,
+    })
+  })
+
+  test('with ?vue query', () => {
+    expect(parseId('/foo/bar.vue?vue&type=script')).toEqual({
+      fileName: '/foo/bar.vue',
+      query: { vue: true },
+      prefix: undefined,
+    })
+  })
+
+  test('with prefix', () => {
+    expect(parseId(`${componentWrapPrefix}/foo/bar.vue`)).toEqual({
+      fileName: '/foo/bar.vue',
+      query: {},
+      prefix: componentWrapPrefix,
+    })
+  })
+
+  test('with prefix and names', () => {
+    expect(parseId(`${componentWrapPrefix}/foo/bar.vue?names=default,Foo`)).toEqual({
+      fileName: '/foo/bar.vue',
+      query: { names: ['default', 'Foo'] },
+      prefix: componentWrapPrefix,
+    })
+  })
+
+  test('names without prefix', () => {
+    expect(parseId('/foo/bar.vue?names=A,B')).toEqual({
+      fileName: '/foo/bar.vue',
+      query: { names: ['A', 'B'] },
+      prefix: undefined,
+    })
+  })
+})

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import { globSync } from 'glob'
 
+import { componentWrapPrefix } from './generate.js'
+
 // -----------------------------
 // Custom Element Paths
 // -----------------------------
@@ -34,25 +36,42 @@ export function resolvePattern(pattern: string | string[], root: string): string
 
 export interface ParsedIdQuery {
   vue?: boolean
+  names?: string[]
 }
 
 /**
- * Parses a file ID into filename and query parts
+ * Parses a file ID into filename and query parts.
+ * Handles the `\0visle:wrap:` prefix and `names` query param.
  */
 export function parseId(id: string): {
   fileName: string
   query: ParsedIdQuery
+  prefix?: string
 } {
-  const [fileName, searchParams] = id.split('?')
+  let prefix: string | undefined
+  let raw = id
+
+  if (raw.startsWith(componentWrapPrefix)) {
+    prefix = componentWrapPrefix
+    raw = raw.slice(componentWrapPrefix.length)
+  }
+
+  const [fileName, searchParams] = raw.split('?')
   const parsed = new URLSearchParams(searchParams)
 
   const query: ParsedIdQuery = {}
   if (parsed.has('vue')) {
     query.vue = true
   }
+  const names = parsed.get('names')
+  if (names) {
+    query.names = names.split(',')
+  }
+
   return {
     fileName: fileName!,
     query,
+    prefix,
   }
 }
 

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -65,7 +65,7 @@ export function parseId(id: string): {
   }
   const names = parsed.get('names')
   if (names) {
-    query.names = names.split(',')
+    query.names = names.split(',').filter(Boolean)
   }
 
   return {

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -84,9 +84,14 @@ export function manifestPlugin(): ManifestPluginResult {
             continue
           }
 
-          if (chunk.facadeModuleId) {
-            const relativePath = path.relative(root, chunk.facadeModuleId)
-            envJsMap.set(relativePath, chunk.fileName)
+          // Map entry modules paths to output chunk path.
+          // Using moduleIds rather than facadeModuleId because it can be disappeared.
+          // (e.g., barrel files merged with their re-export targets by Rollup)
+          for (const moduleId of chunk.moduleIds) {
+            if (this.getModuleInfo(moduleId)?.isEntry) {
+              const moduleRelativePath = path.relative(root, moduleId)
+              envJsMap.set(moduleRelativePath, chunk.fileName)
+            }
           }
         }
 

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -21,6 +21,13 @@ interface ServerTransformPluginResult {
 export function serverTransformPlugin(): ServerTransformPluginResult {
   const islandPaths = new Set<string>()
 
+  /**
+   * Map from importer file path → Map<resolvedSourcePath, Set<importedName>>
+   * Tracks which imports need wrapping.
+   * Populated by the transform hook, consumed by resolveId.
+   */
+  const componentNameMap = new Map<string, Map<string, Set<string>>>()
+
   let viteConfig: ResolvedConfig
 
   const plugin: Plugin = {
@@ -38,23 +45,52 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
     buildStart() {
       islandPaths.clear()
+      componentNameMap.clear()
     },
 
     async resolveId(id, importer) {
-      // Redirect .vue imports to wrapper virtual modules.
+      // Redirect imports to wrapper virtual modules.
       // Skip when the importer is a wrapper module to avoid infinite recursion.
+      const parsedImporter = importer ? parseId(importer) : undefined
+      if (parsedImporter?.prefix === componentWrapPrefix) {
+        return
+      }
+
       const { fileName, query } = parseId(id)
 
-      if (fileName.endsWith('.vue') && !query.vue) {
-        const isFromWrapper = importer?.startsWith(componentWrapPrefix)
-        if (!isFromWrapper) {
-          const resolved = await this.resolve(id, importer, { skipSelf: true })
-          if (!resolved) {
-            return null
-          }
+      // Skip .vue sub-requests (e.g. ?vue&type=script)
+      if (fileName.endsWith('.vue') && query.vue) {
+        return
+      }
 
-          return componentWrapPrefix + resolved.id
-        }
+      const importerPath = parsedImporter?.fileName
+      const nameMap = importerPath ? componentNameMap.get(importerPath) : undefined
+
+      // For .vue files, always redirect to wrapper (default import).
+      // For non-.vue files, only redirect if componentNameMap has entries.
+      const isVue = fileName.endsWith('.vue')
+      if (!isVue && !nameMap) {
+        return
+      }
+
+      const resolved = await this.resolve(id, importer, { skipSelf: true })
+      if (!resolved) {
+        return null
+      }
+
+      const absolutePath = resolved.id
+      const names = nameMap?.get(absolutePath)
+
+      if (isVue) {
+        const allNames = new Set(names)
+        allNames.add('default')
+        const namesQuery = `?names=${[...allNames].join(',')}`
+        return componentWrapPrefix + absolutePath + namesQuery
+      }
+
+      if (names && names.size > 0) {
+        const namesQuery = `?names=${[...names].join(',')}`
+        return componentWrapPrefix + absolutePath + namesQuery
       }
     },
 
@@ -62,17 +98,21 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       // Handle virtual JS modules for component wrapping.
       // These use non-.vue IDs to prevent the Vue plugin from processing them
       // and corrupting its shared descriptor cache.
-      if (id.startsWith(componentWrapPrefix)) {
-        const filePath = id.slice(componentWrapPrefix.length)
-        const componentRelativePath = path.relative(viteConfig.root, filePath)
+      const { prefix, fileName, query } = parseId(id)
+
+      if (prefix === componentWrapPrefix) {
+        const componentRelativePath = path.relative(viteConfig.root, fileName)
         const customElementEntryRelativePath = path.relative(
           viteConfig.root,
           customElementEntryPath,
         )
+        const importedNames = query.names ?? []
+
         return generateComponentWrapperCode(
-          filePath,
+          fileName,
           componentRelativePath,
           customElementEntryRelativePath,
+          importedNames,
         )
       }
     },
@@ -95,7 +135,7 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         return null
       }
 
-      // Build tag-name-to-import-source map from <script setup>
+      // Build tag-name-to-import-source map from <script> block
       const importMap = buildImportMap(descriptor, id)
 
       // Find elements with v-client:load
@@ -117,21 +157,11 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
             }
           }
 
-          const source = importInfo.source
-          let resolvedPath: string | undefined
-
           // Note: skipSelf only works when this.resolve is called from resolveId.
           // From transform, our resolveId still runs and wraps the result with a
           // virtual module prefix, so we need to unwrap it.
-          const resolved = await this.resolve(source, id)
-          if (resolved) {
-            const resolvedId = resolved.id
-            if (resolvedId.startsWith(componentWrapPrefix)) {
-              resolvedPath = resolvedId.slice(componentWrapPrefix.length)
-            } else {
-              resolvedPath = resolvedId
-            }
-          }
+          const resolved = await this.resolve(importInfo.source, id)
+          const resolvedPath = resolved ? parseId(resolved.id).fileName : undefined
 
           return {
             tag: node.tag,
@@ -158,6 +188,19 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         }
 
         islandPaths.add(resolvedPath)
+
+        // Record import name so resolveId can include it in the names query
+        let nameMap = componentNameMap.get(fileName)
+        if (!nameMap) {
+          nameMap = new Map()
+          componentNameMap.set(fileName, nameMap)
+        }
+        let names = nameMap.get(resolvedPath)
+        if (!names) {
+          names = new Set()
+          nameMap.set(resolvedPath, names)
+        }
+        names.add(importInfo.importedName)
       }
     },
   }

--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -17,7 +17,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('extracts multiple .vue imports', () => {
@@ -30,11 +30,14 @@ describe('buildImportMap', () => {
       `)
       const map = buildImportMap(descriptor, 'test.vue')
       expect(map.size).toBe(2)
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
-      expect(map.get('Header')).toEqual({ source: '../components/Header.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
+      expect(map.get('Header')).toEqual({
+        source: '../components/Header.vue',
+        importedName: 'default',
+      })
     })
 
-    test('ignores non-.vue imports', () => {
+    test('includes all imports regardless of extension', () => {
       const descriptor = parseSfc(`
         <script setup>
         import { ref } from 'vue'
@@ -44,14 +47,14 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.size).toBe(1)
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
+      expect(map.get('ref')).toEqual({ source: 'vue', importedName: 'ref' })
+      expect(map.get('utils')).toEqual({ source: './utils.ts', importedName: 'default' })
     })
 
-    test('returns empty map when no .vue imports', () => {
+    test('returns empty map when no imports', () => {
       const descriptor = parseSfc(`
         <script setup>
-        import { ref } from 'vue'
         </script>
         <template><div /></template>
       `)
@@ -74,7 +77,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports renamed components', () => {
@@ -91,7 +94,10 @@ describe('buildImportMap', () => {
       `)
       const map = buildImportMap(descriptor, 'test.vue')
       expect(map.size).toBe(1)
-      expect(map.get('RenamedCounter')).toEqual({ source: './OptionsCounter.vue' })
+      expect(map.get('RenamedCounter')).toEqual({
+        source: './OptionsCounter.vue',
+        importedName: 'default',
+      })
       expect(map.has('OptionsCounter')).toBe(false)
     })
 
@@ -108,7 +114,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('my-counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('my-counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports string-literal "components" key', () => {
@@ -124,7 +130,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('falls back to import names without components option', () => {
@@ -138,7 +144,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('falls back to import names without export default', () => {
@@ -149,7 +155,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports export default fn({ ... }) pattern', () => {
@@ -166,7 +172,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports TypeScript lang', () => {
@@ -182,7 +188,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports JSX lang', () => {
@@ -198,7 +204,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('supports TSX lang', () => {
@@ -214,19 +220,7 @@ describe('buildImportMap', () => {
         <template><div /></template>
       `)
       const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
-    })
-
-    test('ignores named imports (non-default)', () => {
-      const descriptor = parseSfc(`
-        <script>
-        import { Counter } from './Counter.vue'
-        export default {}
-        </script>
-        <template><div /></template>
-      `)
-      const map = buildImportMap(descriptor, 'test.vue')
-      expect(map.size).toBe(0)
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
 
     test('handles multiple imports with components mapping', () => {
@@ -245,8 +239,8 @@ describe('buildImportMap', () => {
       `)
       const map = buildImportMap(descriptor, 'test.vue')
       expect(map.size).toBe(2)
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
-      expect(map.get('MyHeader')).toEqual({ source: './Header.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
+      expect(map.get('MyHeader')).toEqual({ source: './Header.vue', importedName: 'default' })
     })
 
     test('ignores components entry referencing unknown import', () => {
@@ -264,7 +258,7 @@ describe('buildImportMap', () => {
       `)
       const map = buildImportMap(descriptor, 'test.vue')
       expect(map.size).toBe(1)
-      expect(map.get('Counter')).toEqual({ source: './Counter.vue' })
+      expect(map.get('Counter')).toEqual({ source: './Counter.vue', importedName: 'default' })
     })
   })
 

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -6,6 +6,7 @@ import { babelParse, compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
 
 export interface ImportInfo {
   source: string
+  importedName: string // 'default' for default imports, or the named export name
 }
 
 /**
@@ -20,11 +21,10 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
 
     if (imports) {
       for (const [name, binding] of Object.entries(imports)) {
-        if (binding.source.endsWith('.vue')) {
-          map.set(name, {
-            source: binding.source,
-          })
-        }
+        map.set(name, {
+          source: binding.source,
+          importedName: binding.imported,
+        })
       }
     }
 
@@ -46,15 +46,19 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
       plugins,
     })
 
-    // Step 1: Build importName → source map from import declarations
-    const importSources = new Map<string, string>()
+    // Step 1: Build importName → ImportInfo map from import declarations
+    const importSources = new Map<string, ImportInfo>()
     for (const node of ast.program.body) {
       if (node.type === 'ImportDeclaration') {
         const source = node.source.value
-        if (typeof source === 'string' && source.endsWith('.vue')) {
+        if (typeof source === 'string') {
           for (const specifier of node.specifiers) {
             if (specifier.type === 'ImportDefaultSpecifier') {
-              importSources.set(specifier.local.name, source)
+              importSources.set(specifier.local.name, { source, importedName: 'default' })
+            } else if (specifier.type === 'ImportSpecifier') {
+              const imported = specifier.imported
+              const importedName = imported.type === 'Identifier' ? imported.name : imported.value
+              importSources.set(specifier.local.name, { source, importedName })
             }
           }
         }
@@ -112,14 +116,14 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
     // Step 4: Combine — use componentMap if available, otherwise fall back to import names
     if (componentMap.size > 0) {
       for (const [tagName, importName] of componentMap) {
-        const source = importSources.get(importName)
-        if (source) {
-          map.set(tagName, { source })
+        const info = importSources.get(importName)
+        if (info) {
+          map.set(tagName, info)
         }
       }
     } else {
-      for (const [importName, source] of importSources) {
-        map.set(importName, { source })
+      for (const [importName, info] of importSources) {
+        map.set(importName, info)
       }
     }
   }

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -48,9 +48,7 @@ export class VueIsland extends HTMLElement {
 
     const entryComponent = module[importedName]
     if (!entryComponent) {
-      console.error(
-        `[visle] Export "${importedName}" not found in module "${entry}"`,
-      )
+      console.error(`[visle] Export "${importedName}" not found in module "${entry}"`)
       return
     }
 

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -38,6 +38,7 @@ export class VueIsland extends HTMLElement {
     }
 
     const serializedProps = this.getAttribute('serialized-props') ?? '{}'
+    const importedName = this.getAttribute('imported-name') ?? 'default'
 
     const module = await loadModule(entry)
 
@@ -45,7 +46,7 @@ export class VueIsland extends HTMLElement {
       return
     }
 
-    const entryComponent = module.default
+    const entryComponent = module[importedName]
     const parsedProps = tryParseProps(serializedProps)
 
     this.#app = createSSRApp(entryComponent, parsedProps)

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -47,6 +47,13 @@ export class VueIsland extends HTMLElement {
     }
 
     const entryComponent = module[importedName]
+    if (!entryComponent) {
+      console.error(
+        `[visle] Export "${importedName}" not found in module "${entry}"`,
+      )
+      return
+    }
+
     const parsedProps = tryParseProps(serializedProps)
 
     this.#app = createSSRApp(entryComponent, parsedProps)

--- a/src/server/component-wrapper.ts
+++ b/src/server/component-wrapper.ts
@@ -14,6 +14,7 @@ function addCssIdsToContext(context: RenderContext, cssIds: string[]) {
 export function createComponentWrapper(
   normalizedRelativePath: string,
   normalizedEntryRelativePath: string,
+  importedName: string,
   OriginalComponent: Component,
 ) {
   return defineComponent({
@@ -63,6 +64,7 @@ export function createComponentWrapper(
             {
               entry: clientImportId,
               'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),
+              'imported-name': importedName === 'default' ? undefined : importedName,
             },
             [h(OriginalComponent, attrs, slots)],
           )

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -178,7 +178,10 @@ exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
   <h1>
     Page
   </h1>
-  <vue-island entry="/components/barrel.ts">
+  <vue-island
+    entry="/components/barrel.ts"
+    imported-name="Counter"
+  >
     <button>
       Count: 0
     </button>
@@ -197,7 +200,10 @@ exports[`Dev Server SSR > 'Island with named import' 1`] = `
   <h1>
     Page
   </h1>
-  <vue-island entry="/components/named-import.ts">
+  <vue-island
+    entry="/components/named-import.ts"
+    imported-name="Counter"
+  >
     <button>
       Count: 0
     </button>

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -167,6 +167,44 @@ exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 </div>
 `;
 
+exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
+<script
+  type="module"
+  src="/@visle/entry"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/components/barrel.ts">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
+exports[`Dev Server SSR > 'Island with named import' 1`] = `
+<script
+  type="module"
+  src="/@visle/entry"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/components/named-import.ts">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
 <script
   type="module"
@@ -357,6 +395,7 @@ declare module 'visle' {
     'with-options-api': ComponentProps<typeof import('./pages/with-options-api.vue')['default']>
     'with-options-api-renamed': ComponentProps<typeof import('./pages/with-options-api-renamed.vue')['default']>
     'with-nested-island': ComponentProps<typeof import('./pages/with-nested-island.vue')['default']>
+    'with-named-import': ComponentProps<typeof import('./pages/with-named-import.vue')['default']>
     'with-multiple-islands': ComponentProps<typeof import('./pages/with-multiple-islands.vue')['default']>
     'with-mount-variation': ComponentProps<typeof import('./pages/with-mount-variation.vue')['default']>
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
@@ -366,6 +405,7 @@ declare module 'visle' {
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>
     'with-css-src-alias': ComponentProps<typeof import('./pages/with-css-src-alias.vue')['default']>
     'with-css-module': ComponentProps<typeof import('./pages/with-css-module.vue')['default']>
+    'with-barrel-import': ComponentProps<typeof import('./pages/with-barrel-import.vue')['default']>
     'static': ComponentProps<typeof import('./pages/static.vue')['default']>
     'named-export': ComponentProps<typeof import('./pages/named-export.vue')['default']>
     'document': ComponentProps<typeof import('./pages/document.vue')['default']>

--- a/test/__snapshots__/hydration.test.ts.snap
+++ b/test/__snapshots__/hydration.test.ts.snap
@@ -1,5 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Client-side Hydration > 'Island with barrel import' 1`] = `
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island
+    entry="/assets/Counter-[hash].js"
+    imported-name="Counter"
+  >
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
+exports[`Client-side Hydration > 'Island with named import' 1`] = `
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island
+    entry="/assets/named-import-[hash].js"
+    imported-name="Counter"
+  >
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Client-side Hydration > 'Island with props' 1`] = `
 <div>
   <vue-island

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -175,6 +175,52 @@ exports[`Production Build SSR > 'Island with alias import' 1`] = `
 </div>
 `;
 
+exports[`Production Build SSR > 'Island with barrel import' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<script
+  type="module"
+  src="/assets/custom-element-[hash].js"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/assets/Counter-[hash].js">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
+exports[`Production Build SSR > 'Island with named import' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/client-entry-[hash].css"
+>
+<script
+  type="module"
+  src="/assets/custom-element-[hash].js"
+  async
+>
+</script>
+<div>
+  <h1>
+    Page
+  </h1>
+  <vue-island entry="/assets/named-import-[hash].js">
+    <button>
+      Count: 0
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Production Build SSR > 'Island with options API renamed compo…' 1`] = `
 <link
   rel="stylesheet"
@@ -404,6 +450,7 @@ exports[`Production Build SSR > Build output files 1`] = `
   "assets/_plugin-vue_export-helper-[hash].js",
   "assets/client-entry-[hash].css",
   "assets/custom-element-[hash].js",
+  "assets/named-import-[hash].js",
   "assets/vue.runtime.esm-bundler-[hash].js",
 ]
 `;
@@ -426,6 +473,8 @@ exports[`Production Build SSR > Build output files 2`] = `
     "components/OptionsCounter.vue": "assets/OptionsCounter-[hash].js",
     "components/Outer.vue": "assets/Outer-[hash].js",
     "components/StyledCounter.vue": "assets/StyledCounter-[hash].js",
+    "components/barrel.ts": "assets/Counter-[hash].js",
+    "components/named-import.ts": "assets/named-import-[hash].js",
   },
 }
 `;
@@ -446,6 +495,7 @@ declare module 'visle' {
     'with-options-api': ComponentProps<typeof import('./pages/with-options-api.vue')['default']>
     'with-options-api-renamed': ComponentProps<typeof import('./pages/with-options-api-renamed.vue')['default']>
     'with-nested-island': ComponentProps<typeof import('./pages/with-nested-island.vue')['default']>
+    'with-named-import': ComponentProps<typeof import('./pages/with-named-import.vue')['default']>
     'with-multiple-islands': ComponentProps<typeof import('./pages/with-multiple-islands.vue')['default']>
     'with-mount-variation': ComponentProps<typeof import('./pages/with-mount-variation.vue')['default']>
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
@@ -455,6 +505,7 @@ declare module 'visle' {
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>
     'with-css-src-alias': ComponentProps<typeof import('./pages/with-css-src-alias.vue')['default']>
     'with-css-module': ComponentProps<typeof import('./pages/with-css-module.vue')['default']>
+    'with-barrel-import': ComponentProps<typeof import('./pages/with-barrel-import.vue')['default']>
     'static': ComponentProps<typeof import('./pages/static.vue')['default']>
     'named-export': ComponentProps<typeof import('./pages/named-export.vue')['default']>
     'document': ComponentProps<typeof import('./pages/document.vue')['default']>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -190,7 +190,10 @@ exports[`Production Build SSR > 'Island with barrel import' 1`] = `
   <h1>
     Page
   </h1>
-  <vue-island entry="/assets/Counter-[hash].js">
+  <vue-island
+    entry="/assets/Counter-[hash].js"
+    imported-name="Counter"
+  >
     <button>
       Count: 0
     </button>
@@ -213,7 +216,10 @@ exports[`Production Build SSR > 'Island with named import' 1`] = `
   <h1>
     Page
   </h1>
-  <vue-island entry="/assets/named-import-[hash].js">
+  <vue-island
+    entry="/assets/named-import-[hash].js"
+    imported-name="Counter"
+  >
     <button>
       Count: 0
     </button>

--- a/test/fixtures/components/barrel.ts
+++ b/test/fixtures/components/barrel.ts
@@ -1,0 +1,1 @@
+export { default as Counter } from './Counter.vue'

--- a/test/fixtures/components/named-import.ts
+++ b/test/fixtures/components/named-import.ts
@@ -1,0 +1,14 @@
+import { defineComponent, h, ref } from 'vue'
+
+export const Counter = defineComponent({
+  props: {
+    count: {
+      type: Number,
+      default: 0,
+    },
+  },
+  setup(props) {
+    const current = ref(props.count)
+    return () => h('button', `Count: ${current.value}`)
+  },
+})

--- a/test/fixtures/pages/with-barrel-import.vue
+++ b/test/fixtures/pages/with-barrel-import.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { Counter } from '../components/barrel'
+</script>
+
+<template>
+  <div>
+    <h1>Page</h1>
+    <Counter v-client:load />
+  </div>
+</template>

--- a/test/fixtures/pages/with-named-import.vue
+++ b/test/fixtures/pages/with-named-import.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { Counter } from '../components/named-import'
+</script>
+
+<template>
+  <div>
+    <h1>Page</h1>
+    <Counter v-client:load />
+  </div>
+</template>

--- a/test/fixtures/vue-shim.d.ts
+++ b/test/fixtures/vue-shim.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+
+  const component: DefineComponent
+  export default component
+}

--- a/test/hydration.test.ts
+++ b/test/hydration.test.ts
@@ -14,6 +14,8 @@ const hydrationCases: { name: string; component: string; props?: Record<string, 
   { name: 'Island with props', component: 'with-island-props' },
   { name: 'Nested island', component: 'with-nested-island' },
   { name: 'Multiple islands on the same page', component: 'with-multiple-islands' },
+  { name: 'Island with named import', component: 'with-named-import' },
+  { name: 'Island with barrel import', component: 'with-barrel-import' },
 ]
 
 /**

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -32,6 +32,8 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'CSS with style src', component: 'with-css-src' },
   { name: 'CSS with style src alias', component: 'with-css-src-alias' },
   { name: 'Same component as island and server', component: 'with-mount-variation' },
+  { name: 'Island with named import', component: 'with-named-import' },
+  { name: 'Island with barrel import', component: 'with-barrel-import' },
 ]
 
 /**


### PR DESCRIPTION
## Summary

- Support named imports (e.g., `import { Foo } from './components.island'`) in addition to default imports for island components
- Handle barrel files that re-export island components (e.g., `export { default as Foo } from './Foo.island.vue'`)
- Wrap each named export with `createComponentWrapper` so they hydrate correctly on the client

## Test plan

- [x] Unit tests for path parsing and SFC analysis
- [x] Integration tests for named import and barrel file rendering (dev and prod)
- [x] Hydration tests for named import and barrel file scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for named component imports (in addition to default) and barrel-style re-exports—islands can now reference specific exported component names.

* **New Features**
  * Islands and custom elements now carry import-name metadata so client/server hydration targets the correct exported symbol.

* **Tests**
  * Added and updated tests covering named imports, barrel imports, and related parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->