### PR TITLE
refactor: remove server component wrapper

### DIFF
--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -22,16 +22,13 @@ export function generateServerVirtualEntryCode(entryDir: string, componentIds: s
 export function generateComponentWrapperCode(
   filePath: string,
   componentRelativePath: string,
-  customElementEntryRelativePath: string,
   importedNames: string[],
 ): string {
   const normalizedFilePath = normalizePath(filePath)
   const normalizedRelativePath = normalizePath(componentRelativePath)
-  const normalizedEntryRelativePath = normalizePath(customElementEntryRelativePath)
 
   const serializedFilePath = JSON.stringify(normalizedFilePath)
   const serializedRelativePath = JSON.stringify(normalizedRelativePath)
-  const serializedEntryRelativePath = JSON.stringify(normalizedEntryRelativePath)
 
   const lines = [
     `import { createComponentWrapper } from 'visle/internal'`,
@@ -45,8 +42,8 @@ export function generateComponentWrapperCode(
     for (const [i, name] of importedNames.entries()) {
       lines.push(
         name === 'default'
-          ? `export default createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`
-          : `export const ${name} = createComponentWrapper(${serializedRelativePath}, ${serializedEntryRelativePath}, ${JSON.stringify(name)}, __visle_${i})`,
+          ? `export default createComponentWrapper(${serializedRelativePath}, ${JSON.stringify(name)}, __visle_${i})`
+          : `export const ${name} = createComponentWrapper(${serializedRelativePath}, ${JSON.stringify(name)}, __visle_${i})`,
       )
     }
   }

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -31,7 +31,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
   const { plugin: serverTransform, islandPaths } = serverTransformPlugin()
   const virtualFile = virtualFilePlugin(resolvedConfig)
-  const { plugin: manifest, getManifestData } = manifestPlugin()
+  const { plugin: manifest, getManifestData } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
 
   const orchestrationPlugin: Plugin = {

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -1,10 +1,14 @@
 import path from 'node:path'
 
-import { normalizePath, Plugin, ResolvedConfig } from 'vite'
+import { normalizePath, Plugin } from 'vite'
+
+import type { ResolvedVisleConfig } from '../config.js'
 
 export const manifestFileName = 'visle-manifest.json'
 
 export interface ManifestData {
+  base: string
+  entryDir: string
   cssMap: Record<string, string[]>
   jsMap: Record<string, string>
 }
@@ -17,8 +21,8 @@ interface ManifestPluginResult {
 /**
  * Vite plugin that collects CSS/JS manifest data during bundle generation.
  */
-export function manifestPlugin(): ManifestPluginResult {
-  let viteConfig: ResolvedConfig
+export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPluginResult {
+  let base: string
   let cssMap: Map<string, string[]> | undefined
   let jsMap: Map<string, string> | undefined
 
@@ -27,13 +31,13 @@ export function manifestPlugin(): ManifestPluginResult {
     apply: 'build',
     sharedDuringBuild: true,
 
-    configResolved(resolvedConfig) {
-      viteConfig = resolvedConfig
+    configResolved(viteConfig) {
+      base = viteConfig.base
     },
 
     generateBundle(_options, bundle) {
       const envName = this.environment?.name
-      const root = viteConfig.root
+      const root = this.environment?.config.root ?? ''
 
       if (envName === 'style') {
         const envCssMap = new Map<string, string[]>()
@@ -136,6 +140,8 @@ export function manifestPlugin(): ManifestPluginResult {
 
     getManifestData(): ManifestData {
       return {
+        base,
+        entryDir: visleConfig.entryDir,
         cssMap: Object.fromEntries(cssMap ?? new Map()),
         jsMap: Object.fromEntries(jsMap ?? new Map()),
       }

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { normalizePath, Plugin } from 'vite'
 
 import type { ResolvedVisleConfig } from '../config.js'
+import { customElementEntryPath } from '../paths.js'
 
 export const manifestFileName = 'visle-manifest.json'
 
@@ -11,6 +12,7 @@ export interface ManifestData {
   entryDir: string
   cssMap: Record<string, string[]>
   jsMap: Record<string, string>
+  customElementEntry: string
 }
 
 interface ManifestPluginResult {
@@ -25,6 +27,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
   let base: string
   let cssMap: Map<string, string[]> | undefined
   let jsMap: Map<string, string> | undefined
+  let customElementEntry: string | undefined
 
   const plugin: Plugin = {
     name: 'visle:manifest',
@@ -131,6 +134,9 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
         }
 
         jsMap = envJsMap
+
+        const entryKey = normalizePath(path.relative(root, customElementEntryPath))
+        customElementEntry = envJsMap.get(entryKey)
       }
     },
   }
@@ -144,6 +150,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
         entryDir: visleConfig.entryDir,
         cssMap: Object.fromEntries(cssMap ?? new Map()),
         jsMap: Object.fromEntries(jsMap ?? new Map()),
+        customElementEntry: customElementEntry ?? '',
       }
     },
   }

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -14,7 +14,7 @@ interface ServerTransformPluginResult {
 
 /**
  * Vite plugin that transforms Vue SFC imports on the server environment.
- * - Redirects `.vue` imports to component wrapper virtual modules
+ * - Redirects island component imports to component wrapper virtual modules
  * - Loads wrapper virtual modules with generated code
  * - Detects `v-client:load` directives and collects island component paths for the islands build
  */
@@ -53,24 +53,14 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       // Skip when the importer is a wrapper module to avoid infinite recursion.
       const parsedImporter = importer ? parseId(importer) : undefined
       if (parsedImporter?.prefix === componentWrapPrefix) {
-        return
+        return null
       }
 
       const { fileName, query } = parseId(id)
 
       // Skip .vue sub-requests (e.g. ?vue&type=script)
       if (fileName.endsWith('.vue') && query.vue) {
-        return
-      }
-
-      const importerPath = parsedImporter?.fileName
-      const nameMap = importerPath ? componentNameMap.get(importerPath) : undefined
-
-      // For .vue files, always redirect to wrapper (default import).
-      // For non-.vue files, only redirect if componentNameMap has entries.
-      const isVue = fileName.endsWith('.vue')
-      if (!isVue && !nameMap) {
-        return
+        return null
       }
 
       const resolved = await this.resolve(id, importer, { skipSelf: true })
@@ -78,20 +68,16 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
         return null
       }
 
-      const absolutePath = resolved.id
-      const names = nameMap?.get(absolutePath)
+      const importerPath = parsedImporter?.fileName
+      const nameMap = importerPath ? componentNameMap.get(importerPath) : undefined
+      const names = nameMap?.get(resolved.id)
 
-      if (isVue) {
-        const allNames = new Set(names)
-        allNames.add('default')
-        const namesQuery = `?names=${[...allNames].join(',')}`
-        return componentWrapPrefix + absolutePath + namesQuery
+      if (!names || names.size === 0) {
+        return null
       }
 
-      if (names && names.size > 0) {
-        const namesQuery = `?names=${[...names].join(',')}`
-        return componentWrapPrefix + absolutePath + namesQuery
-      }
+      const namesQuery = `?names=${[...names].join(',')}`
+      return componentWrapPrefix + resolved.id + namesQuery
     },
 
     load(id) {

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -4,7 +4,7 @@ import type { Plugin, ResolvedConfig } from 'vite'
 import { parse } from 'vue/compiler-sfc'
 
 import { generateComponentWrapperCode, componentWrapPrefix } from '../generate.js'
-import { customElementEntryPath, parseId } from '../paths.js'
+import { parseId } from '../paths.js'
 import { buildImportMap, findVClientElements } from '../sfc-analysis.js'
 
 interface ServerTransformPluginResult {
@@ -88,18 +88,9 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
       if (prefix === componentWrapPrefix) {
         const componentRelativePath = path.relative(viteConfig.root, fileName)
-        const customElementEntryRelativePath = path.relative(
-          viteConfig.root,
-          customElementEntryPath,
-        )
         const importedNames = query.names ?? []
 
-        return generateComponentWrapperCode(
-          fileName,
-          componentRelativePath,
-          customElementEntryRelativePath,
-          importedNames,
-        )
+        return generateComponentWrapperCode(fileName, componentRelativePath, importedNames)
       }
     },
 

--- a/src/server/component-wrapper.ts
+++ b/src/server/component-wrapper.ts
@@ -6,7 +6,6 @@ import { islandSymbol } from './symbol.js'
 
 export function createComponentWrapper(
   normalizedRelativePath: string,
-  normalizedEntryRelativePath: string,
   importedName: string,
   OriginalComponent: Component,
 ) {
@@ -32,15 +31,8 @@ export function createComponentWrapper(
         let clientImportId = ''
 
         onServerPrefetch(async () => {
-          const [resolvedClientImportId, entryImportId] = await Promise.all([
-            manifest.getClientImportId(normalizedRelativePath),
-            manifest.getClientImportId(normalizedEntryRelativePath),
-          ])
-
-          clientImportId = resolvedClientImportId
-
-          context.loadJs ??= new Set()
-          context.loadJs.add(entryImportId)
+          clientImportId = await manifest.getClientImportId(normalizedRelativePath)
+          context.hasIsland = true
         })
 
         if (inIsland) {

--- a/src/server/component-wrapper.ts
+++ b/src/server/component-wrapper.ts
@@ -4,13 +4,6 @@ import { defineComponent, h, useSSRContext, useAttrs, inject, provide, onServerP
 import type { RenderContext } from './render.js'
 import { islandSymbol } from './symbol.js'
 
-function addCssIdsToContext(context: RenderContext, cssIds: string[]) {
-  context.loadCss ??= new Set()
-  for (const cssId of cssIds) {
-    context.loadCss.add(cssId)
-  }
-}
-
 export function createComponentWrapper(
   normalizedRelativePath: string,
   normalizedEntryRelativePath: string,
@@ -26,30 +19,28 @@ export function createComponentWrapper(
 
     setup(props, { slots }) {
       const attrs = useAttrs()
-      const context: RenderContext = useSSRContext()!
-      const manifest = context.manifest!
 
       const isIsland = props.__visle_client__
 
       if (isIsland) {
+        const context: RenderContext = useSSRContext()!
+        const manifest = context.manifest!
+
         const inIsland = inject(islandSymbol, false)
         provide(islandSymbol, true)
 
         let clientImportId = ''
 
         onServerPrefetch(async () => {
-          const [resolvedClientImportId, entryImportId, cssIds] = await Promise.all([
+          const [resolvedClientImportId, entryImportId] = await Promise.all([
             manifest.getClientImportId(normalizedRelativePath),
             manifest.getClientImportId(normalizedEntryRelativePath),
-            manifest.getDependingClientCssIds(normalizedRelativePath),
           ])
 
           clientImportId = resolvedClientImportId
 
           context.loadJs ??= new Set()
           context.loadJs.add(entryImportId)
-
-          addCssIdsToContext(context, cssIds)
         })
 
         if (inIsland) {
@@ -71,13 +62,7 @@ export function createComponentWrapper(
         }
       }
 
-      // Server-only path: just load CSS and render original component
-      onServerPrefetch(async () => {
-        const cssIds = await manifest.getDependingClientCssIds(normalizedRelativePath)
-
-        addCssIdsToContext(context, cssIds)
-      })
-
+      // Server-only path: just render original component
       return () => h(OriginalComponent, attrs, slots)
     },
   })

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -44,17 +44,9 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
         },
         logLevel: 'silent',
       }).then((devServer) => {
-        const visleConfig = getVisleConfig(devServer.config)
-        const serverEnv = devServer.environments.server as RunnableDevEnvironment
-
         return {
           devServer,
-          manifest: createDevManifest(
-            devServer.config,
-            visleConfig.entryDir,
-            (id, importer) => devServer.pluginContainer.resolveId(id, importer).then((r) => r?.id),
-            () => serverEnv.moduleGraph,
-          ),
+          manifest: createDevManifest(devServer),
         }
       })
     }

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -44,10 +44,16 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
         },
         logLevel: 'silent',
       }).then((devServer) => {
+        const visleConfig = getVisleConfig(devServer.config)
+        const serverEnv = devServer.environments.server as RunnableDevEnvironment
+
         return {
           devServer,
-          manifest: createDevManifest(devServer.config, (id, importer) =>
-            devServer.pluginContainer.resolveId(id, importer).then((r) => r?.id),
+          manifest: createDevManifest(
+            devServer.config,
+            visleConfig.entryDir,
+            (id, importer) => devServer.pluginContainer.resolveId(id, importer).then((r) => r?.id),
+            () => serverEnv.moduleGraph,
           ),
         }
       })

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -27,6 +27,7 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
@@ -43,6 +44,7 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
@@ -60,10 +62,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual([])
   })
@@ -78,10 +81,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual([
       expect.stringMatching(/^\/src\/foo\.vue\?vue&type=style&index=0&scoped=[\da-f]+&lang\.css$/),
@@ -98,10 +102,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/src/foo.vue?vue&type=style&index=0&lang.module.css'])
   })
@@ -117,10 +122,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/src/foo.css?vue&type=style&index=0&src=true&lang.css'])
   })
@@ -136,10 +142,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual([
       expect.stringMatching(
@@ -158,6 +165,7 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async (id) => {
         if (id === '@/styles/foo.css') {
           return path.join(root, 'src/styles/foo.css')
@@ -166,7 +174,7 @@ describe('createDevManifest', () => {
       },
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/src/styles/foo.css?vue&type=style&index=0&src=true&lang.css'])
   })
@@ -181,10 +189,11 @@ describe('createDevManifest', () => {
         base: '/',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/unknown-package/style.css?vue&type=style&index=0&src=true&lang.css'])
   })
@@ -196,6 +205,7 @@ describe('createDevManifest', () => {
         base: 'https://example.com/prefix',
         server: {},
       },
+      'src',
       async () => undefined,
     )
 
@@ -213,12 +223,77 @@ describe('createDevManifest', () => {
           origin: 'http://localhost:3000',
         },
       },
+      'src',
       async () => undefined,
     )
 
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe('http://localhost:3000/src/foo.vue')
+  })
+
+  test('getEntryCssIds collects CSS transitively from module graph', async () => {
+    const childCode = '<template><div></div></template><style>h1 { color: red; }</style>'
+    const parentCode = '<template><div></div></template>'
+    fs.writeFileSync(path.join(root, 'src/child.vue'), childCode)
+    fs.writeFileSync(path.join(root, 'src/parent.vue'), parentCode)
+
+    // Create a mock module graph
+    const childNode = {
+      id: path.join(root, 'src/child.vue'),
+      importedModules: new Set(),
+    }
+    const parentNode = {
+      id: path.join(root, 'src/parent.vue'),
+      importedModules: new Set([childNode]),
+    }
+
+    const moduleGraph = {
+      getModuleById(id: string) {
+        if (id === parentNode.id) return parentNode
+        if (id === childNode.id) return childNode
+        return undefined
+      },
+    }
+
+    const manifest = createDevManifest(
+      {
+        root,
+        base: '/',
+        server: {},
+      },
+      'src',
+      async () => undefined,
+      () => moduleGraph as any,
+    )
+
+    const result = await manifest.getEntryCssIds('parent')
+
+    // Parent has no styles, child has one style block
+    expect(result).toEqual(['/src/child.vue?vue&type=style&index=0&lang.css'])
+  })
+
+  test('getEntryCssIds returns empty array for unknown entry', async () => {
+    const moduleGraph = {
+      getModuleById() {
+        return undefined
+      },
+    }
+
+    const manifest = createDevManifest(
+      {
+        root,
+        base: '/',
+        server: {},
+      },
+      'src',
+      async () => undefined,
+      () => moduleGraph as any,
+    )
+
+    const result = await manifest.getEntryCssIds('unknown')
+
+    expect(result).toEqual([])
   })
 })
 
@@ -234,12 +309,16 @@ describe('loadManifest', () => {
   })
 
   function writeManifest(data: {
+    base?: string
+    entryDir?: string
     cssMap?: Record<string, string[]>
     jsMap?: Record<string, string>
   }): void {
     fs.writeFileSync(
       path.join(serverOutDir, manifestFileName),
       JSON.stringify({
+        base: '/',
+        entryDir: 'pages',
         cssMap: {},
         jsMap: {},
         ...data,
@@ -252,7 +331,7 @@ describe('loadManifest', () => {
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(serverOutDir, '/')
+    const manifest = await loadManifest(serverOutDir)
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe('/foo-1234.js')
@@ -263,20 +342,20 @@ describe('loadManifest', () => {
       jsMap: {},
     })
 
-    const manifest = await loadManifest(serverOutDir, '/')
+    const manifest = await loadManifest(serverOutDir)
 
     await expect(manifest.getClientImportId('src/foo.vue')).rejects.toThrow(
       'src/foo.vue not found in manifest JS map',
     )
   })
 
-  test('get depending css ids from css map', async () => {
+  test('get entry css ids from css map', async () => {
     writeManifest({
-      cssMap: { 'src/foo.vue': ['foo-1234.css'] },
+      cssMap: { 'pages/foo.vue': ['foo-1234.css'] },
     })
 
-    const manifest = await loadManifest(serverOutDir, '/')
-    const result = await manifest.getDependingClientCssIds('src/foo.vue')
+    const manifest = await loadManifest(serverOutDir)
+    const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/foo-1234.css'])
   })
@@ -286,12 +365,25 @@ describe('loadManifest', () => {
     ['/prefix', '/prefix/foo-1234.js'],
   ] as const)('prepend base to file path: %s', async ([base, expected]) => {
     writeManifest({
+      base,
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(serverOutDir, base)
+    const manifest = await loadManifest(serverOutDir)
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe(expected)
+  })
+
+  test('getEntryCssIds uses entryDir from manifest data', async () => {
+    writeManifest({
+      entryDir: 'views',
+      cssMap: { 'views/index.vue': ['index-1234.css'] },
+    })
+
+    const manifest = await loadManifest(serverOutDir)
+    const result = await manifest.getEntryCssIds('index')
+
+    expect(result).toEqual(['/index-1234.css'])
   })
 })

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -1,35 +1,63 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 
+import { createServer, type RunnableDevEnvironment, type ViteDevServer } from 'vite'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
+import { visle } from '../build/index.ts'
 import { customElementEntryPath, virtualCustomElementEntryPath } from '../build/paths.ts'
 import { manifestFileName } from '../build/plugins/manifest.ts'
 import { createDevManifest, loadManifest } from './manifest.ts'
 
+const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/server')
+
+let root: string
+
+beforeEach(() => {
+  fs.mkdirSync(generatedDir, { recursive: true })
+  root = fs.mkdtempSync(path.join(generatedDir, 'manifest-'))
+  fs.mkdirSync(path.join(root, 'pages'), { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
 describe('createDevManifest', () => {
-  let root: string
+  let server: ViteDevServer | undefined
 
-  beforeEach(() => {
-    root = fs.mkdtempSync(path.join(os.tmpdir(), 'visle-test-'))
-    fs.mkdirSync(path.join(root, 'src'), { recursive: true })
+  afterEach(async () => {
+    await server?.close()
+    server = undefined
   })
 
-  afterEach(() => {
-    fs.rmSync(root, { recursive: true, force: true })
-  })
+  async function createTestServer(
+    options: {
+      base?: string
+      serverOrigin?: string
+      resolve?: { alias?: Record<string, string> }
+    } = {},
+  ) {
+    server = await createServer({
+      configFile: false,
+      root,
+      base: options.base ?? '/',
+      plugins: [visle()],
+      resolve: options.resolve,
+      appType: 'custom',
+      server: {
+        middlewareMode: true,
+        origin: options.serverOrigin,
+      },
+      optimizeDeps: { noDiscovery: true },
+      logLevel: 'silent',
+    })
+    return server
+  }
 
   test('get custom element entry path as virtual path', async () => {
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
     const relativePath = path.relative(root, customElementEntryPath)
     const result = await manifest.getClientImportId(relativePath)
@@ -38,33 +66,19 @@ describe('createDevManifest', () => {
   })
 
   test('get a relative path from the root directory', async () => {
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
-    const result = await manifest.getClientImportId('src/foo.vue')
+    const result = await manifest.getClientImportId('pages/foo.vue')
 
-    expect(result).toBe('/src/foo.vue')
+    expect(result).toBe('/pages/foo.vue')
   })
 
   test('return empty id array for css without <style>', async () => {
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), '<template><div></div></template>')
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), '<template><div></div></template>')
 
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
     const result = await manifest.getEntryCssIds('foo')
 
@@ -73,125 +87,86 @@ describe('createDevManifest', () => {
 
   test('return ids for <style> blocks in code', async () => {
     const code = '<template><div></div></template><style scoped>h1 { color: red; }</style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
 
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
-
-    const result = await manifest.getEntryCssIds('foo')
-
-    expect(result).toEqual([
-      expect.stringMatching(/^\/src\/foo\.vue\?vue&type=style&index=0&scoped=[\da-f]+&lang\.css$/),
-    ])
-  })
-
-  test('return ids for <style> block as css module', async () => {
-    const code = '<template><div></div></template><style module>h1 { color: red; }</style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
-
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
-
-    const result = await manifest.getEntryCssIds('foo')
-
-    expect(result).toEqual(['/src/foo.vue?vue&type=style&index=0&lang.module.css'])
-  })
-
-  test('return ids for <style src> blocks', async () => {
-    const code = '<template><div></div></template><style src="./foo.css"></style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
-    fs.writeFileSync(path.join(root, 'src/foo.css'), 'h1 { color: red; }')
-
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
-
-    const result = await manifest.getEntryCssIds('foo')
-
-    expect(result).toEqual(['/src/foo.css?vue&type=style&index=0&src=true&lang.css'])
-  })
-
-  test('return ids for <style src> blocks with scoped', async () => {
-    const code = '<template><div></div></template><style src="./foo.css" scoped></style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
-    fs.writeFileSync(path.join(root, 'src/foo.css'), 'h1 { color: red; }')
-
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
     const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual([
       expect.stringMatching(
-        /^\/src\/foo\.css\?vue&type=style&index=0&src=[\da-f]+&scoped=[\da-f]+&lang\.css$/,
+        /^\/pages\/foo\.vue\?vue&type=style&index=0&scoped=[\da-f]+&lang\.css$/,
+      ),
+    ])
+  })
+
+  test('return ids for <style> block as css module', async () => {
+    const code = '<template><div></div></template><style module>h1 { color: red; }</style>'
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
+
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
+
+    const result = await manifest.getEntryCssIds('foo')
+
+    expect(result).toEqual(['/pages/foo.vue?vue&type=style&index=0&lang.module.css'])
+  })
+
+  test('return ids for <style src> blocks', async () => {
+    const code = '<template><div></div></template><style src="./foo.css"></style>'
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.css'), 'h1 { color: red; }')
+
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
+
+    const result = await manifest.getEntryCssIds('foo')
+
+    expect(result).toEqual(['/pages/foo.css?vue&type=style&index=0&src=true&lang.css'])
+  })
+
+  test('return ids for <style src> blocks with scoped', async () => {
+    const code = '<template><div></div></template><style src="./foo.css" scoped></style>'
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.css'), 'h1 { color: red; }')
+
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
+
+    const result = await manifest.getEntryCssIds('foo')
+
+    expect(result).toEqual([
+      expect.stringMatching(
+        /^\/pages\/foo\.css\?vue&type=style&index=0&src=[\da-f]+&scoped=[\da-f]+&lang\.css$/,
       ),
     ])
   })
 
   test('resolve non-relative <style src> path via resolveId', async () => {
     const code = '<template><div></div></template><style src="@/styles/foo.css"></style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
+    fs.mkdirSync(path.join(root, 'pages/styles'), { recursive: true })
+    fs.writeFileSync(path.join(root, 'pages/styles/foo.css'), 'h1 { color: red; }')
 
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
+    const s = await createTestServer({
+      resolve: {
+        alias: { '@': path.join(root, 'pages') },
       },
-      'src',
-      async (id) => {
-        if (id === '@/styles/foo.css') {
-          return path.join(root, 'src/styles/foo.css')
-        }
-        return undefined
-      },
-    )
+    })
+    const manifest = createDevManifest(s)
 
     const result = await manifest.getEntryCssIds('foo')
 
-    expect(result).toEqual(['/src/styles/foo.css?vue&type=style&index=0&src=true&lang.css'])
+    expect(result).toEqual(['/pages/styles/foo.css?vue&type=style&index=0&src=true&lang.css'])
   })
 
   test('fall back to raw src value when resolveId returns undefined', async () => {
     const code = '<template><div></div></template><style src="unknown-package/style.css"></style>'
-    fs.writeFileSync(path.join(root, 'src/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
 
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
     const result = await manifest.getEntryCssIds('foo')
 
@@ -199,115 +174,61 @@ describe('createDevManifest', () => {
   })
 
   test('return url with path part of base', async () => {
-    const manifest = createDevManifest(
-      {
-        root,
-        base: 'https://example.com/prefix',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer({ base: 'https://example.com/prefix' })
+    const manifest = createDevManifest(s)
 
-    const result = await manifest.getClientImportId('src/foo.vue')
+    const result = await manifest.getClientImportId('pages/foo.vue')
 
-    expect(result).toBe('/prefix/src/foo.vue')
+    expect(result).toBe('/prefix/pages/foo.vue')
   })
 
   test('return url with specified dev server origin', async () => {
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {
-          origin: 'http://localhost:3000',
-        },
-      },
-      'src',
-      async () => undefined,
-    )
+    const s = await createTestServer({ serverOrigin: 'http://localhost:3000' })
+    const manifest = createDevManifest(s)
 
-    const result = await manifest.getClientImportId('src/foo.vue')
+    const result = await manifest.getClientImportId('pages/foo.vue')
 
-    expect(result).toBe('http://localhost:3000/src/foo.vue')
+    expect(result).toBe('http://localhost:3000/pages/foo.vue')
   })
 
   test('getEntryCssIds collects CSS transitively from module graph', async () => {
-    const childCode = '<template><div></div></template><style>h1 { color: red; }</style>'
-    const parentCode = '<template><div></div></template>'
-    fs.writeFileSync(path.join(root, 'src/child.vue'), childCode)
-    fs.writeFileSync(path.join(root, 'src/parent.vue'), parentCode)
+    const childCode =
+      '<template><div></div></template><script setup>const a = 1</script><style>h1 { color: red; }</style>'
+    const parentCode =
+      '<template><Child /></template><script setup>import Child from "./child.vue"</script>'
+    fs.writeFileSync(path.join(root, 'pages/child.vue'), childCode)
+    fs.writeFileSync(path.join(root, 'pages/parent.vue'), parentCode)
 
-    // Create a mock module graph
-    const childNode = {
-      id: path.join(root, 'src/child.vue'),
-      importedModules: new Set(),
-    }
-    const parentNode = {
-      id: path.join(root, 'src/parent.vue'),
-      importedModules: new Set([childNode]),
-    }
+    const s = await createTestServer()
+    const serverEnv = s.environments.server as RunnableDevEnvironment
 
-    const moduleGraph = {
-      getModuleById(id: string) {
-        if (id === parentNode.id) return parentNode
-        if (id === childNode.id) return childNode
-        return undefined
-      },
-    }
+    // Load the module via SSR runner to populate the server module graph
+    await serverEnv.runner.import(path.join(root, 'pages/parent.vue'))
 
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-      () => moduleGraph as any,
-    )
-
+    const manifest = createDevManifest(s)
     const result = await manifest.getEntryCssIds('parent')
 
-    // Parent has no styles, child has one style block
-    expect(result).toEqual(['/src/child.vue?vue&type=style&index=0&lang.css'])
+    // Child has one style block
+    expect(result).toEqual(['/pages/child.vue?vue&type=style&index=0&lang.css'])
   })
 
-  test('getEntryCssIds returns empty array for unknown entry', async () => {
-    const moduleGraph = {
-      getModuleById() {
-        return undefined
-      },
-    }
-
-    const manifest = createDevManifest(
-      {
-        root,
-        base: '/',
-        server: {},
-      },
-      'src',
-      async () => undefined,
-      () => moduleGraph as any,
+  test('getEntryCssIds falls back to file parsing when entry is not in module graph', async () => {
+    fs.writeFileSync(
+      path.join(root, 'pages/foo.vue'),
+      '<template><div></div></template><style>h1 { color: red; }</style>',
     )
 
-    const result = await manifest.getEntryCssIds('unknown')
+    const s = await createTestServer()
+    const manifest = createDevManifest(s)
 
-    expect(result).toEqual([])
+    // foo is not in the module graph (never transformed), falls back to parsing
+    const result = await manifest.getEntryCssIds('foo')
+
+    expect(result).toEqual(['/pages/foo.vue?vue&type=style&index=0&lang.css'])
   })
 })
 
 describe('loadManifest', () => {
-  let serverOutDir: string
-
-  beforeEach(() => {
-    serverOutDir = fs.mkdtempSync(path.join(os.tmpdir(), 'visle-test-'))
-  })
-
-  afterEach(() => {
-    fs.rmSync(serverOutDir, { recursive: true, force: true })
-  })
-
   function writeManifest(data: {
     base?: string
     entryDir?: string
@@ -315,7 +236,7 @@ describe('loadManifest', () => {
     jsMap?: Record<string, string>
   }): void {
     fs.writeFileSync(
-      path.join(serverOutDir, manifestFileName),
+      path.join(root, manifestFileName),
       JSON.stringify({
         base: '/',
         entryDir: 'pages',
@@ -331,7 +252,7 @@ describe('loadManifest', () => {
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(serverOutDir)
+    const manifest = await loadManifest(root)
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe('/foo-1234.js')
@@ -342,7 +263,7 @@ describe('loadManifest', () => {
       jsMap: {},
     })
 
-    const manifest = await loadManifest(serverOutDir)
+    const manifest = await loadManifest(root)
 
     await expect(manifest.getClientImportId('src/foo.vue')).rejects.toThrow(
       'src/foo.vue not found in manifest JS map',
@@ -354,7 +275,7 @@ describe('loadManifest', () => {
       cssMap: { 'pages/foo.vue': ['foo-1234.css'] },
     })
 
-    const manifest = await loadManifest(serverOutDir)
+    const manifest = await loadManifest(root)
     const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/foo-1234.css'])
@@ -369,7 +290,7 @@ describe('loadManifest', () => {
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(serverOutDir)
+    const manifest = await loadManifest(root)
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe(expected)
@@ -381,7 +302,7 @@ describe('loadManifest', () => {
       cssMap: { 'views/index.vue': ['index-1234.css'] },
     })
 
-    const manifest = await loadManifest(serverOutDir)
+    const manifest = await loadManifest(root)
     const result = await manifest.getEntryCssIds('index')
 
     expect(result).toEqual(['/index-1234.css'])

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
+import type { EnvironmentModuleGraph, EnvironmentModuleNode } from 'vite'
 import { parse, SFCBlock } from 'vue/compiler-sfc'
 
 import { generateComponentId } from '../build/component-id.js'
@@ -9,17 +10,17 @@ import { manifestFileName, type ManifestData } from '../build/plugins/manifest.j
 
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
-  getDependingClientCssIds(componentRelativePath: string): Promise<string[]>
+  getEntryCssIds(componentPath: string): Promise<string[]>
 }
 
 /**
  * Loads the manifest file from serverOutDir for production SSR.
  */
-export async function loadManifest(serverOutDir: string, base: string): Promise<RuntimeManifest> {
+export async function loadManifest(serverOutDir: string): Promise<RuntimeManifest> {
   const manifestPath = path.join(serverOutDir, manifestFileName)
-  const basePath = base.replace(/\/$/, '')
 
   const data: ManifestData = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
+  const basePath = data.base.replace(/\/$/, '')
 
   return {
     async getClientImportId(componentRelativePath: string): Promise<string> {
@@ -30,8 +31,9 @@ export async function loadManifest(serverOutDir: string, base: string): Promise<
       return `${basePath}/${file}`
     },
 
-    async getDependingClientCssIds(componentRelativePath: string): Promise<string[]> {
-      const cssIds = data.cssMap[componentRelativePath] ?? []
+    async getEntryCssIds(componentPath: string): Promise<string[]> {
+      const entryRelativePath = `${data.entryDir}/${componentPath}.vue`
+      const cssIds = data.cssMap[entryRelativePath] ?? []
       return cssIds.map((cssId) => `${basePath}/${cssId}`)
     },
   }
@@ -46,7 +48,9 @@ export function createDevManifest(
     base: string
     server: { origin?: string }
   },
+  entryDir: string,
   resolveId: (id: string, importer: string) => Promise<string | undefined>,
+  getModuleGraph?: () => EnvironmentModuleGraph,
 ): RuntimeManifest {
   const { root, base } = viteConfig
 
@@ -56,6 +60,52 @@ export function createDevManifest(
 
   function applyServeBase(filePath: string): string {
     return `${origin}${basePath}${filePath}`
+  }
+
+  async function getComponentCssIds(componentRelativePath: string): Promise<string[]> {
+    const absPath = path.resolve(root, componentRelativePath)
+
+    if (!absPath.endsWith('.vue')) {
+      return []
+    }
+
+    const code = await fs.readFile(absPath, 'utf-8')
+    const descriptor = parse(code).descriptor
+    const componentId = generateComponentId(componentRelativePath, code, false)
+
+    return Promise.all(
+      descriptor.styles.map(async (style, i) => {
+        const attrsQuery = attrsToQuery(style.attrs, 'css')
+        const srcQuery = style.src ? (style.scoped ? `&src=${componentId}` : '&src=true') : ''
+        const scopedQuery = style.scoped ? `&scoped=${componentId}` : ''
+        const query = `?vue&type=style&index=${i}${srcQuery}${scopedQuery}`
+
+        let stylePath: string
+        if (!style.src) {
+          stylePath = `/${componentRelativePath}`
+        } else if (style.src.startsWith('.')) {
+          stylePath =
+            '/' +
+            path.posix.normalize(path.posix.join(path.dirname(componentRelativePath), style.src))
+        } else {
+          const resolved = await resolveId(style.src, absPath)
+          if (resolved) {
+            stylePath = '/' + path.relative(root, resolved)
+          } else {
+            stylePath = '/' + style.src
+          }
+        }
+
+        let styleId = `${stylePath}${query}${attrsQuery}`
+
+        if (style.module) {
+          // inject `.module` before extension so vite handles it as css module
+          styleId = styleId.replace(/\.(\w+)$/, '.module.$1')
+        }
+
+        return applyServeBase(styleId)
+      }),
+    )
   }
 
   return {
@@ -69,50 +119,43 @@ export function createDevManifest(
       return applyServeBase(`/${componentRelativePath}`)
     },
 
-    async getDependingClientCssIds(componentRelativePath: string): Promise<string[]> {
-      const absPath = path.resolve(root, componentRelativePath)
+    async getEntryCssIds(componentPath: string): Promise<string[]> {
+      const entryRelativePath = `${entryDir}/${componentPath}.vue`
 
-      if (!absPath.endsWith('.vue')) {
+      if (!getModuleGraph) {
+        return getComponentCssIds(entryRelativePath)
+      }
+
+      const moduleGraph = getModuleGraph()
+      const entryAbsPath = path.resolve(root, entryRelativePath)
+      const entryMod = moduleGraph.getModuleById(entryAbsPath)
+      if (!entryMod) {
         return []
       }
 
-      const code = await fs.readFile(absPath, 'utf-8')
-      const descriptor = parse(code).descriptor
-      const componentId = generateComponentId(componentRelativePath, code, false)
+      // Walk module graph to find all transitively imported .vue files
+      const vueRelativePaths: string[] = []
+      const visited = new Set<string>()
 
-      return Promise.all(
-        descriptor.styles.map(async (style, i) => {
-          const attrsQuery = attrsToQuery(style.attrs, 'css')
-          const srcQuery = style.src ? (style.scoped ? `&src=${componentId}` : '&src=true') : ''
-          const scopedQuery = style.scoped ? `&scoped=${componentId}` : ''
-          const query = `?vue&type=style&index=${i}${srcQuery}${scopedQuery}`
+      const walk = (mod: EnvironmentModuleNode) => {
+        if (!mod.id || visited.has(mod.id)) {
+          return
+        }
+        visited.add(mod.id)
 
-          let stylePath: string
-          if (!style.src) {
-            stylePath = `/${componentRelativePath}`
-          } else if (style.src.startsWith('.')) {
-            stylePath =
-              '/' +
-              path.posix.normalize(path.posix.join(path.dirname(componentRelativePath), style.src))
-          } else {
-            const resolved = await resolveId(style.src, absPath)
-            if (resolved) {
-              stylePath = '/' + path.relative(root, resolved)
-            } else {
-              stylePath = '/' + style.src
-            }
-          }
+        if (mod.id.endsWith('.vue')) {
+          vueRelativePaths.push(path.relative(root, mod.id))
+        }
 
-          let styleId = `${stylePath}${query}${attrsQuery}`
+        for (const imported of mod.importedModules) {
+          walk(imported)
+        }
+      }
+      walk(entryMod)
 
-          if (style.module) {
-            // inject `.module` before extension so vite handles it as css module
-            styleId = styleId.replace(/\.(\w+)$/, '.module.$1')
-          }
-
-          return applyServeBase(styleId)
-        }),
-      )
+      // Collect CSS from all discovered .vue files
+      const cssArrays = await Promise.all(vueRelativePaths.map((p) => getComponentCssIds(p)))
+      return cssArrays.flat()
     },
   }
 }

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import type { EnvironmentModuleGraph, EnvironmentModuleNode } from 'vite'
+import type { EnvironmentModuleNode, RunnableDevEnvironment, ViteDevServer } from 'vite'
 import { parse, SFCBlock } from 'vue/compiler-sfc'
 
 import { generateComponentId } from '../build/component-id.js'
+import { getVisleConfig } from '../build/config.js'
 import { virtualCustomElementEntryPath, customElementEntryPath } from '../build/paths.js'
 import { manifestFileName, type ManifestData } from '../build/plugins/manifest.js'
 
@@ -42,20 +43,13 @@ export async function loadManifest(serverOutDir: string): Promise<RuntimeManifes
 /**
  * Creates a dev-mode RuntimeManifest that resolves paths using Vite's dev server.
  */
-export function createDevManifest(
-  viteConfig: {
-    root: string
-    base: string
-    server: { origin?: string }
-  },
-  entryDir: string,
-  resolveId: (id: string, importer: string) => Promise<string | undefined>,
-  getModuleGraph?: () => EnvironmentModuleGraph,
-): RuntimeManifest {
-  const { root, base } = viteConfig
+export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
+  const serverEnv = devServer.environments.server as RunnableDevEnvironment
+  const { root, base } = devServer.config
+  const { entryDir } = getVisleConfig(devServer.config)
 
   // Normalize origin value
-  const origin = viteConfig.server.origin?.replace(/\/$/, '') ?? ''
+  const origin = devServer.config.server.origin?.replace(/\/$/, '') ?? ''
   const basePath = basePathForDev(base)
 
   function applyServeBase(filePath: string): string {
@@ -88,7 +82,8 @@ export function createDevManifest(
             '/' +
             path.posix.normalize(path.posix.join(path.dirname(componentRelativePath), style.src))
         } else {
-          const resolved = await resolveId(style.src, absPath)
+          const result = await serverEnv.pluginContainer.resolveId(style.src, absPath)
+          const resolved = result?.id
           if (resolved) {
             stylePath = '/' + path.relative(root, resolved)
           } else {
@@ -121,16 +116,12 @@ export function createDevManifest(
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {
       const entryRelativePath = `${entryDir}/${componentPath}.vue`
-
-      if (!getModuleGraph) {
-        return getComponentCssIds(entryRelativePath)
-      }
-
-      const moduleGraph = getModuleGraph()
       const entryAbsPath = path.resolve(root, entryRelativePath)
-      const entryMod = moduleGraph.getModuleById(entryAbsPath)
+
+      const entryMod = serverEnv.moduleGraph.getModuleById(entryAbsPath)
       if (!entryMod) {
-        return []
+        // Module not yet loaded in the module graph, fall back to parsing the entry file
+        return getComponentCssIds(entryRelativePath)
       }
 
       // Walk module graph to find all transitively imported .vue files

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -12,6 +12,7 @@ import { manifestFileName, type ManifestData } from '../build/plugins/manifest.j
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
   getEntryCssIds(componentPath: string): Promise<string[]>
+  getCustomElementEntryId(): Promise<string>
 }
 
 /**
@@ -36,6 +37,10 @@ export async function loadManifest(serverOutDir: string): Promise<RuntimeManifes
       const entryRelativePath = `${data.entryDir}/${componentPath}.vue`
       const cssIds = data.cssMap[entryRelativePath] ?? []
       return cssIds.map((cssId) => `${basePath}/${cssId}`)
+    },
+
+    async getCustomElementEntryId(): Promise<string> {
+      return `${basePath}/${data.customElementEntry}`
     },
   }
 }
@@ -112,6 +117,10 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
       }
 
       return applyServeBase(`/${componentRelativePath}`)
+    },
+
+    async getCustomElementEntryId(): Promise<string> {
+      return applyServeBase(virtualCustomElementEntryPath)
     },
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {

--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -40,7 +40,7 @@ describe('createRender', () => {
   })
 
   describe('isDev = false', () => {
-    const emptyManifest = JSON.stringify({ cssMap: {}, jsMap: {} })
+    const emptyManifest = JSON.stringify({ base: '/', entryDir: 'pages', cssMap: {}, jsMap: {} })
 
     test('renders vue component with props', async () => {
       const render = createRender({

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -20,9 +20,8 @@ export interface RenderLoader {
 }
 
 export interface RenderContext {
-  loadCss?: Set<string>
-  loadJs?: Set<string>
   manifest?: RuntimeManifest
+  hasIsland?: boolean
 }
 
 type RenderArgs<P> = {} extends P ? [props?: P] : [props: P]
@@ -71,14 +70,18 @@ export function createRender<T extends Record<string, any> = Record<string, any>
     const app = createApp(component, props)
     const rendered = await renderToString(app, context)
 
+    const manifest = context.manifest!
+
     // Collect CSS for the page entry after rendering so module graph is populated
-    const cssIds = await context.manifest!.getEntryCssIds(componentPath)
-    context.loadCss ??= new Set()
-    for (const cssId of cssIds) {
-      context.loadCss.add(cssId)
+    const css = await manifest.getEntryCssIds(componentPath)
+
+    // Collect JS for custom element entry if any island component was rendered
+    const js: string[] = []
+    if (context.hasIsland) {
+      js.push(await manifest.getCustomElementEntryId())
     }
 
-    return transformWithRenderContext(rendered, context)
+    return transformWithRenderContext(rendered, { css, js })
   }
 
   render.setLoader = (newLoader: RenderLoader) => {

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -12,14 +12,6 @@ export interface RenderOptions {
    * Pass the same value of Visle Vite plugin's serverOutDir.
    */
   serverOutDir?: string
-
-  /**
-   * Base public path for serving client assets.
-   * Same as Vite's `base` config. Can be an absolute path (e.g., `/prefix/`)
-   * or a full URL (e.g., `https://cdn.example.com/`).
-   * @default '/'
-   */
-  base?: string
 }
 
 export interface RenderLoader {
@@ -63,8 +55,7 @@ export function createRender<T extends Record<string, any> = Record<string, any>
     async getManifest() {
       if (!cachedManifest) {
         const serverOutDir = options.serverOutDir ?? defaultConfig.serverOutDir
-        const base = options.base ?? '/'
-        cachedManifest = await loadManifest(serverOutDir, base)
+        cachedManifest = await loadManifest(serverOutDir)
       }
       return cachedManifest
     },
@@ -79,6 +70,13 @@ export function createRender<T extends Record<string, any> = Record<string, any>
 
     const app = createApp(component, props)
     const rendered = await renderToString(app, context)
+
+    // Collect CSS for the page entry after rendering so module graph is populated
+    const cssIds = await context.manifest!.getEntryCssIds(componentPath)
+    context.loadCss ??= new Set()
+    for (const cssId of cssIds) {
+      context.loadCss.add(cssId)
+    }
 
     return transformWithRenderContext(rendered, context)
   }

--- a/src/server/transform.test.ts
+++ b/src/server/transform.test.ts
@@ -1,27 +1,20 @@
 import { describe, expect, test } from 'vitest'
 
-import { RenderContext } from './render.ts'
 import { transformWithRenderContext } from './transform.ts'
 
 describe('transform rendered html', () => {
   test('prepend if the html is incomplete', () => {
     const html = '<div>Hello</div>'
-    const context: RenderContext = {
-      loadCss: new Set(['style.css']),
-    }
 
-    const result = transformWithRenderContext(html, context)
+    const result = transformWithRenderContext(html, { css: ['style.css'], js: [] })
 
     expect(result).toBe('<link rel="stylesheet" href="style.css"><div>Hello</div>')
   })
 
   test('append into the end of a head element', () => {
     const html = '<html><head><title>Hello</title></head></html>'
-    const context: RenderContext = {
-      loadCss: new Set(['style.css']),
-    }
 
-    const result = transformWithRenderContext(html, context)
+    const result = transformWithRenderContext(html, { css: ['style.css'], js: [] })
 
     expect(result).toBe(
       '<html><head><title>Hello</title><link rel="stylesheet" href="style.css"></head></html>',
@@ -30,11 +23,8 @@ describe('transform rendered html', () => {
 
   test('insert before a body element', () => {
     const html = '<html><body><div>Hello</div></body></html>'
-    const context: RenderContext = {
-      loadCss: new Set(['style.css']),
-    }
 
-    const result = transformWithRenderContext(html, context)
+    const result = transformWithRenderContext(html, { css: ['style.css'], js: [] })
 
     expect(result).toBe(
       '<html><link rel="stylesheet" href="style.css"><body><div>Hello</div></body></html>',
@@ -43,11 +33,8 @@ describe('transform rendered html', () => {
 
   test('insert before a body element with an attribute', () => {
     const html = '<html><body class="dark"><div>Hello</div></body></html>'
-    const context: RenderContext = {
-      loadCss: new Set(['style.css']),
-    }
 
-    const result = transformWithRenderContext(html, context)
+    const result = transformWithRenderContext(html, { css: ['style.css'], js: [] })
 
     expect(result).toBe(
       '<html><link rel="stylesheet" href="style.css"><body class="dark"><div>Hello</div></body></html>',

--- a/src/server/transform.ts
+++ b/src/server/transform.ts
@@ -1,25 +1,24 @@
-import { RenderContext } from './render.js'
+export interface Injection {
+  css: string[]
+  js: string[]
+}
 
-export function transformWithRenderContext(html: string, context: RenderContext): string {
-  const injecting = createInjectingHtml(context)
+export function transformWithRenderContext(html: string, injection: Injection): string {
+  const injecting = createInjectingHtml(injection)
   const point = findInjectionPoint(html)
 
   return html.slice(0, point) + injecting + html.slice(point)
 }
 
-function createInjectingHtml(context: RenderContext): string {
+function createInjectingHtml(injection: Injection): string {
   let injecting = ''
 
-  if (context.loadCss) {
-    for (const href of context.loadCss) {
-      injecting += `<link rel="stylesheet" href="${href}">`
-    }
+  for (const href of injection.css) {
+    injecting += `<link rel="stylesheet" href="${href}">`
   }
 
-  if (context.loadJs) {
-    for (const src of context.loadJs) {
-      injecting += `<script type="module" src="${src}" async></script>`
-    }
+  for (const src of injection.js) {
+    injecting += `<script type="module" src="${src}" async></script>`
   }
 
   return injecting

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -141,7 +141,11 @@ exports[`Dev Server SSR > 'Dynamic import shared CSS' 1`] = `
   <h1>
     Dynamic Shared Styled Page
   </h1>
-  <vue-island entry="/components/StyledCounter.vue">
+  <vue-island entry="/components/DynamicImport.vue">
+    <!--[-->
+    <h2>
+      Async Component
+    </h2>
     <button data-v-[scoped]>
       Styled Count: 0
     </button>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -133,7 +133,11 @@ exports[`Production Build SSR > 'Dynamic import shared CSS' 1`] = `
   <h1>
     Dynamic Shared Styled Page
   </h1>
-  <vue-island entry="/assets/StyledCounter-[hash].js">
+  <vue-island entry="/assets/DynamicImport-[hash].js">
+    <!--[-->
+    <h2>
+      Async Component
+    </h2>
     <button data-v-[scoped]>
       Styled Count: 0
     </button>
@@ -437,6 +441,7 @@ exports[`Production Build SSR > Build output files 1`] = `
   "assets/Counter-[hash].js",
   "assets/CounterA-[hash].js",
   "assets/CounterB-[hash].js",
+  "assets/DynamicImport-[hash].js",
   "assets/ExternalStyledCounter-[hash].js",
   "assets/Inner-[hash].js",
   "assets/NamedExportIsland-[hash].js",
@@ -459,6 +464,7 @@ exports[`Production Build SSR > Build output files 1`] = `
 
 exports[`Production Build SSR > Build output files 2`] = `
 {
+  "base": "/",
   "cssMap": {
     "pages/document.vue": [],
     "pages/named-export.vue": [],
@@ -499,12 +505,14 @@ exports[`Production Build SSR > Build output files 2`] = `
     ],
     "pages/with-slot.vue": [],
   },
+  "entryDir": "pages",
   "jsMap": {
     "../../../../src/client/custom-element.ts": "assets/custom-element-[hash].js",
     "components/AliasStyledCounter.vue": "assets/AliasStyledCounter-[hash].js",
     "components/Counter.vue": "assets/Counter-[hash].js",
     "components/CounterA.vue": "assets/CounterA-[hash].js",
     "components/CounterB.vue": "assets/CounterB-[hash].js",
+    "components/DynamicImport.vue": "assets/DynamicImport-[hash].js",
     "components/ExternalStyledCounter.vue": "assets/ExternalStyledCounter-[hash].js",
     "components/Inner.vue": "assets/Inner-[hash].js",
     "components/NamedExportIsland.vue": "assets/NamedExportIsland-[hash].js",
@@ -571,7 +579,11 @@ exports[`Production Build SSR with manual chunks > dynamic import shared CSS pag
   <h1>
     Dynamic Shared Styled Page
   </h1>
-  <vue-island entry="/assets/StyledCounter-[hash].js">
+  <vue-island entry="/assets/DynamicImport-[hash].js">
+    <!--[-->
+    <h2>
+      Async Component
+    </h2>
     <button data-v-[scoped]>
       Styled Count: 0
     </button>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -505,6 +505,7 @@ exports[`Production Build SSR > Build output files 2`] = `
     ],
     "pages/with-slot.vue": [],
   },
+  "customElementEntry": "assets/custom-element-[hash].js",
   "entryDir": "pages",
   "jsMap": {
     "../../../../src/client/custom-element.ts": "assets/custom-element-[hash].js",

--- a/test/fixtures/components/DynamicImport.vue
+++ b/test/fixtures/components/DynamicImport.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
+
+const StyledCounter = defineAsyncComponent(() => import('./StyledCounter.vue'))
+</script>
+
+<template>
+  <h2>Async Component</h2>
+  <StyledCounter />
+</template>

--- a/test/fixtures/pages/with-dynamic-shared-css.vue
+++ b/test/fixtures/pages/with-dynamic-shared-css.vue
@@ -1,13 +1,11 @@
 <script setup>
-import { defineAsyncComponent } from 'vue'
-
-const StyledCounter = defineAsyncComponent(() => import('../components/StyledCounter.vue'))
+import DynamicImport from '../components/DynamicImport.vue'
 </script>
 
 <template>
   <div>
     <h1>Dynamic Shared Styled Page</h1>
-    <StyledCounter v-client:load />
+    <DynamicImport v-client:load />
   </div>
 </template>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better collection of CSS for dynamically loaded and nested components.
  * Islands/components now emit JS entry info so client scripts can be injected when rendered.

* **Bug Fixes**
  * Fixed CSS resolution for island and transitive component imports.
  * Server rendering now returns collected CSS and JS for proper client hydration.

* **Refactor**
  * Simplified manifest and wrapper generation APIs and manifest loading behavior.

* **Tests**
  * Expanded tests for CSS, dynamic imports, and manifest-root handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->