### PR TITLE
refactor: rename and tidy up islands bootstrap, avoid using babelParse

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "vite": "^7.3.1"
   },
   "devDependencies": {
-    "@babel/parser": "^7.29.0",
     "@babel/types": "^7.29.0",
     "@types/connect": "^3.4.38",
     "@types/diffable-html": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.3)
     devDependencies:
-      '@babel/parser':
-        specifier: ^7.29.0
-        version: 7.29.0
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -8,7 +8,7 @@ import type { Plugin } from 'vite'
 import { generateComponentId } from './component-id.js'
 import { VisleConfig, defaultConfig, setVisleConfig } from './config.js'
 import { serverVirtualEntryId } from './generate.js'
-import { customElementEntryPath, resolveServerComponentIds } from './paths.js'
+import { islandsBootstrapPath, resolveServerComponentIds } from './paths.js'
 import { devStyleSSRPlugin } from './plugins/dev-style-ssr.js'
 import { entryTypesPlugin } from './plugins/entry-types.js'
 import { manifestFileName, manifestPlugin } from './plugins/manifest.js'
@@ -60,9 +60,9 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               outDir: resolvedConfig.clientOutDir,
               emptyOutDir: false,
               rollupOptions: {
-                // Start with custom element entry;
+                // Start with islands bootstrap;
                 // v-client island paths are added after server build
-                input: [customElementEntryPath],
+                input: [islandsBootstrapPath],
                 preserveEntrySignatures: 'allow-extension',
               },
             },

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -8,8 +8,8 @@ import { componentWrapPrefix } from './generate.js'
 // -----------------------------
 // Custom Element Paths
 // -----------------------------
-export const virtualCustomElementEntryPath = '/@visle/entry'
-export const customElementEntryPath = path.resolve(
+export const virtualIslandsBootstrapPath = '/@visle/bootstrap'
+export const islandsBootstrapPath = path.resolve(
   // In Deno, import.meta.dirname can be undefined (in https module).
   // Just casting it to string for now.
   import.meta.dirname as string,

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { normalizePath, Plugin } from 'vite'
 
 import type { ResolvedVisleConfig } from '../config.js'
-import { customElementEntryPath } from '../paths.js'
+import { islandsBootstrapPath } from '../paths.js'
 
 export const manifestFileName = 'visle-manifest.json'
 
@@ -12,7 +12,7 @@ export interface ManifestData {
   entryDir: string
   cssMap: Record<string, string[]>
   jsMap: Record<string, string>
-  customElementEntry: string
+  islandsBootstrap: string
 }
 
 interface ManifestPluginResult {
@@ -27,7 +27,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
   let base: string
   let cssMap: Map<string, string[]> | undefined
   let jsMap: Map<string, string> | undefined
-  let customElementEntry: string | undefined
+  let islandsBootstrap: string | undefined
 
   const plugin: Plugin = {
     name: 'visle:manifest',
@@ -135,8 +135,8 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
 
         jsMap = envJsMap
 
-        const entryKey = normalizePath(path.relative(root, customElementEntryPath))
-        customElementEntry = envJsMap.get(entryKey)
+        const entryKey = normalizePath(path.relative(root, islandsBootstrapPath))
+        islandsBootstrap = envJsMap.get(entryKey)
       }
     },
   }
@@ -150,7 +150,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
         entryDir: visleConfig.entryDir,
         cssMap: Object.fromEntries(cssMap ?? new Map()),
         jsMap: Object.fromEntries(jsMap ?? new Map()),
-        customElementEntry: customElementEntry ?? '',
+        islandsBootstrap: islandsBootstrap ?? '',
       }
     },
   }

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -122,6 +122,12 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
             continue
           }
 
+          // The chunk is islands bootstrap that is Visle-provided
+          if (chunk.facadeModuleId === islandsBootstrapPath) {
+            islandsBootstrap = chunk.fileName
+            continue
+          }
+
           // Map entry modules paths to output chunk path.
           // Using moduleIds rather than facadeModuleId because it can be disappeared.
           // (e.g., barrel files merged with their re-export targets by Rollup)
@@ -134,9 +140,6 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
         }
 
         jsMap = envJsMap
-
-        const entryKey = normalizePath(path.relative(root, islandsBootstrapPath))
-        islandsBootstrap = envJsMap.get(entryKey)
       }
     },
   }

--- a/src/build/plugins/virtual-file.test.ts
+++ b/src/build/plugins/virtual-file.test.ts
@@ -2,7 +2,7 @@ import { createServer, type ViteDevServer } from 'vite'
 import { describe, test, expect, afterEach } from 'vitest'
 
 import { defaultConfig } from '../config.ts'
-import { virtualCustomElementEntryPath } from '../paths.ts'
+import { virtualIslandsBootstrapPath } from '../paths.ts'
 import { virtualFilePlugin } from './virtual-file.ts'
 
 describe('virtualFilePlugin', () => {
@@ -13,7 +13,7 @@ describe('virtualFilePlugin', () => {
     server = undefined
   })
 
-  test('custom element entry is transformable in client environment', async () => {
+  test('islands bootstrap is transformable in client environment', async () => {
     server = await createServer({
       configFile: false,
       plugins: [virtualFilePlugin(defaultConfig)],
@@ -23,7 +23,7 @@ describe('virtualFilePlugin', () => {
       logLevel: 'silent',
     })
 
-    const result = await server.environments.client.transformRequest(virtualCustomElementEntryPath)
+    const result = await server.environments.client.transformRequest(virtualIslandsBootstrapPath)
 
     expect(result).not.toBeNull()
     expect(result!.code).toContain('vue-island')

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -5,8 +5,8 @@ import { Plugin } from 'vite'
 import { ResolvedVisleConfig } from '../config.js'
 import { generateServerVirtualEntryCode, serverVirtualEntryId } from '../generate.js'
 import {
-  customElementEntryPath,
-  virtualCustomElementEntryPath,
+  islandsBootstrapPath,
+  virtualIslandsBootstrapPath,
   resolveServerComponentIds,
 } from '../paths.js'
 
@@ -25,8 +25,8 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
     },
 
     resolveId(id) {
-      if (id === virtualCustomElementEntryPath) {
-        return customElementEntryPath
+      if (id === virtualIslandsBootstrapPath) {
+        return islandsBootstrapPath
       }
 
       if (id === serverVirtualEntryId) {

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -1,8 +1,7 @@
-import type { ParserPlugin } from '@babel/parser'
 import type { ObjectExpression } from '@babel/types'
 import type { ElementNode, TemplateChildNode } from '@vue/compiler-core'
 import { NodeTypes } from '@vue/compiler-core'
-import { babelParse, compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
+import { compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
 
 export interface ImportInfo {
   source: string
@@ -32,23 +31,12 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
   }
 
   if (descriptor.script) {
-    const lang = descriptor.script.lang
-    const plugins: ParserPlugin[] = []
-    if (lang === 'ts' || lang === 'tsx') {
-      plugins.push('typescript')
-    }
-    if (lang === 'jsx' || lang === 'tsx') {
-      plugins.push('jsx')
-    }
-
-    const ast = babelParse(descriptor.script.content, {
-      sourceType: 'module',
-      plugins,
-    })
+    const compiled = compileScript(descriptor, { id })
+    const body = compiled.scriptAst!
 
     // Step 1: Build importName → ImportInfo map from import declarations
     const importSources = new Map<string, ImportInfo>()
-    for (const node of ast.program.body) {
+    for (const node of body) {
       if (node.type === 'ImportDeclaration') {
         const source = node.source.value
         if (typeof source === 'string') {
@@ -68,7 +56,7 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
     // Step 2: Find options object from export default
     // Supports: export default { ... } and export default fn({ ... })
     let optionsObject: ObjectExpression | undefined
-    for (const node of ast.program.body) {
+    for (const node of body) {
       if (node.type === 'ExportDefaultDeclaration') {
         if (node.declaration.type === 'ObjectExpression') {
           // export default { ... }

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -5,7 +5,7 @@ import { createServer, type RunnableDevEnvironment, type ViteDevServer } from 'v
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { visle } from '../build/index.ts'
-import { customElementEntryPath, virtualCustomElementEntryPath } from '../build/paths.ts'
+import { islandsBootstrapPath, virtualIslandsBootstrapPath } from '../build/paths.ts'
 import { manifestFileName } from '../build/plugins/manifest.ts'
 import { createDevManifest, loadManifest } from './manifest.ts'
 
@@ -55,14 +55,14 @@ describe('createDevManifest', () => {
     return server
   }
 
-  test('get custom element entry path as virtual path', async () => {
+  test('get islands bootstrap path as virtual path', async () => {
     const s = await createTestServer()
     const manifest = createDevManifest(s)
 
-    const relativePath = path.relative(root, customElementEntryPath)
+    const relativePath = path.relative(root, islandsBootstrapPath)
     const result = await manifest.getClientImportId(relativePath)
 
-    expect(result).toBe(virtualCustomElementEntryPath)
+    expect(result).toBe(virtualIslandsBootstrapPath)
   })
 
   test('get a relative path from the root directory', async () => {

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -5,7 +5,7 @@ import { createServer, type RunnableDevEnvironment, type ViteDevServer } from 'v
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { visle } from '../build/index.ts'
-import { islandsBootstrapPath, virtualIslandsBootstrapPath } from '../build/paths.ts'
+import { virtualIslandsBootstrapPath } from '../build/paths.ts'
 import { manifestFileName } from '../build/plugins/manifest.ts'
 import { createDevManifest, loadManifest } from './manifest.ts'
 
@@ -59,8 +59,7 @@ describe('createDevManifest', () => {
     const s = await createTestServer()
     const manifest = createDevManifest(s)
 
-    const relativePath = path.relative(root, islandsBootstrapPath)
-    const result = await manifest.getClientImportId(relativePath)
+    const result = await manifest.getIslandsBootstrapId()
 
     expect(result).toBe(virtualIslandsBootstrapPath)
   })

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -6,13 +6,13 @@ import { parse, SFCBlock } from 'vue/compiler-sfc'
 
 import { generateComponentId } from '../build/component-id.js'
 import { getVisleConfig } from '../build/config.js'
-import { virtualCustomElementEntryPath, customElementEntryPath } from '../build/paths.js'
+import { virtualIslandsBootstrapPath, islandsBootstrapPath } from '../build/paths.js'
 import { manifestFileName, type ManifestData } from '../build/plugins/manifest.js'
 
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
   getEntryCssIds(componentPath: string): Promise<string[]>
-  getCustomElementEntryId(): Promise<string>
+  getIslandsBootstrapId(): Promise<string>
 }
 
 /**
@@ -39,8 +39,8 @@ export async function loadManifest(serverOutDir: string): Promise<RuntimeManifes
       return cssIds.map((cssId) => `${basePath}/${cssId}`)
     },
 
-    async getCustomElementEntryId(): Promise<string> {
-      return `${basePath}/${data.customElementEntry}`
+    async getIslandsBootstrapId(): Promise<string> {
+      return `${basePath}/${data.islandsBootstrap}`
     },
   }
 }
@@ -112,15 +112,15 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
     async getClientImportId(componentRelativePath: string): Promise<string> {
       const absPath = path.resolve(root, componentRelativePath)
 
-      if (absPath === customElementEntryPath) {
-        return applyServeBase(virtualCustomElementEntryPath)
+      if (absPath === islandsBootstrapPath) {
+        return applyServeBase(virtualIslandsBootstrapPath)
       }
 
       return applyServeBase(`/${componentRelativePath}`)
     },
 
-    async getCustomElementEntryId(): Promise<string> {
-      return applyServeBase(virtualCustomElementEntryPath)
+    async getIslandsBootstrapId(): Promise<string> {
+      return applyServeBase(virtualIslandsBootstrapPath)
     },
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -6,7 +6,7 @@ import { parse, SFCBlock } from 'vue/compiler-sfc'
 
 import { generateComponentId } from '../build/component-id.js'
 import { getVisleConfig } from '../build/config.js'
-import { virtualIslandsBootstrapPath, islandsBootstrapPath } from '../build/paths.js'
+import { virtualIslandsBootstrapPath } from '../build/paths.js'
 import { manifestFileName, type ManifestData } from '../build/plugins/manifest.js'
 
 export interface RuntimeManifest {
@@ -110,12 +110,6 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
 
   return {
     async getClientImportId(componentRelativePath: string): Promise<string> {
-      const absPath = path.resolve(root, componentRelativePath)
-
-      if (absPath === islandsBootstrapPath) {
-        return applyServeBase(virtualIslandsBootstrapPath)
-      }
-
       return applyServeBase(`/${componentRelativePath}`)
     },
 

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -75,10 +75,10 @@ export function createRender<T extends Record<string, any> = Record<string, any>
     // Collect CSS for the page entry after rendering so module graph is populated
     const css = await manifest.getEntryCssIds(componentPath)
 
-    // Collect JS for custom element entry if any island component was rendered
+    // Collect JS for islands bootstrap if any island component was rendered
     const js: string[] = []
     if (context.hasIsland) {
-      js.push(await manifest.getCustomElementEntryId())
+      js.push(await manifest.getIslandsBootstrapId())
     }
 
     return transformWithRenderContext(rendered, { css, js })

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -21,7 +21,7 @@ exports[`Dev Server SSR > 'CSS with style src alias' 1`] = `
 >
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -48,7 +48,7 @@ exports[`Dev Server SSR > 'CSS with style src' 1`] = `
 >
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -81,7 +81,7 @@ exports[`Dev Server SSR > 'Component with CSS' 1`] = `
 >
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -100,7 +100,7 @@ exports[`Dev Server SSR > 'Component with CSS' 1`] = `
 exports[`Dev Server SSR > 'Component with island' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -133,7 +133,7 @@ exports[`Dev Server SSR > 'Dynamic import shared CSS' 1`] = `
 >
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -161,7 +161,7 @@ exports[`Dev Server SSR > 'Full HTML document with head/body' 1`] = `
     </title>
     <script
       type="module"
-      src="/@visle/entry"
+      src="/@visle/bootstrap"
       async
     >
     </script>
@@ -182,7 +182,7 @@ exports[`Dev Server SSR > 'Full HTML document with head/body' 1`] = `
 exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -201,7 +201,7 @@ exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -223,7 +223,7 @@ exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
 exports[`Dev Server SSR > 'Island with named import' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -245,7 +245,7 @@ exports[`Dev Server SSR > 'Island with named import' 1`] = `
 exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -264,7 +264,7 @@ exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
 exports[`Dev Server SSR > 'Island with options API' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -283,7 +283,7 @@ exports[`Dev Server SSR > 'Island with options API' 1`] = `
 exports[`Dev Server SSR > 'Island with props' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -302,7 +302,7 @@ exports[`Dev Server SSR > 'Island with props' 1`] = `
 exports[`Dev Server SSR > 'Multiple islands on the same page' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -323,7 +323,7 @@ exports[`Dev Server SSR > 'Multiple islands on the same page' 1`] = `
 exports[`Dev Server SSR > 'Named export' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -347,7 +347,7 @@ exports[`Dev Server SSR > 'Named export' 1`] = `
 exports[`Dev Server SSR > 'Nested island' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -374,7 +374,7 @@ exports[`Dev Server SSR > 'Non-ascii file name' 1`] = `
 exports[`Dev Server SSR > 'Same component as island and server' 1`] = `
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>
@@ -421,7 +421,7 @@ exports[`Dev Server SSR > 'Shared CSS common chunk' 1`] = `
 >
 <script
   type="module"
-  src="/@visle/entry"
+  src="/@visle/bootstrap"
   async
 >
 </script>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -508,7 +508,6 @@ exports[`Production Build SSR > Build output files 2`] = `
   "entryDir": "pages",
   "islandsBootstrap": "assets/custom-element-[hash].js",
   "jsMap": {
-    "../../../../src/client/custom-element.ts": "assets/custom-element-[hash].js",
     "components/AliasStyledCounter.vue": "assets/AliasStyledCounter-[hash].js",
     "components/Counter.vue": "assets/Counter-[hash].js",
     "components/CounterA.vue": "assets/CounterA-[hash].js",

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -505,8 +505,8 @@ exports[`Production Build SSR > Build output files 2`] = `
     ],
     "pages/with-slot.vue": [],
   },
-  "customElementEntry": "assets/custom-element-[hash].js",
   "entryDir": "pages",
+  "islandsBootstrap": "assets/custom-element-[hash].js",
   "jsMap": {
     "../../../../src/client/custom-element.ts": "assets/custom-element-[hash].js",
     "components/AliasStyledCounter.vue": "assets/AliasStyledCounter-[hash].js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed unused @babel/parser from development dependencies
  * Refactored internal build system configuration and manifest tracking for bootstrap handling
  * Updated Single File Component parsing implementation
  * Reorganized manifest data structure and runtime API methods for bootstrap identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->