### PR TITLE
fix: support css import during dev mode (fix #87)

### DIFF
--- a/src/build/plugins/dev-style-ssr.ts
+++ b/src/build/plugins/dev-style-ssr.ts
@@ -5,11 +5,7 @@
 
 import type { Plugin } from 'vite'
 
-const cssRE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
-
-function isCSS(id: string): boolean {
-  return cssRE.test(id)
-}
+import { isCSS } from '../../core/path.js'
 
 /**
  * Development-only plugin that removes server-rendered `<link>` style tags

--- a/src/build/plugins/manifest.test.ts
+++ b/src/build/plugins/manifest.test.ts
@@ -3,8 +3,8 @@ import path from 'node:path'
 
 import { beforeEach, afterEach, describe, expect, test } from 'vitest'
 
-import { manifestFileName } from './manifest.ts'
 import { prodBuild } from '../../../test/utils.ts'
+import { manifestFileName } from './manifest.ts'
 
 const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generated__/server')
 

--- a/src/build/plugins/manifest.test.ts
+++ b/src/build/plugins/manifest.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { beforeEach, afterEach, describe, expect, test } from 'vitest'
+
+import { manifestFileName } from './manifest.ts'
+import { prodBuild } from '../../../test/utils.ts'
+
+const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generated__/server')
+
+let root: string
+
+beforeEach(() => {
+  fs.mkdirSync(generatedDir, { recursive: true })
+  root = fs.mkdtempSync(path.join(generatedDir, 'build-manifest-'))
+  fs.mkdirSync(path.join(root, 'pages'), { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('build manifest CSS order', () => {
+  test('cssMap preserves depth-first import order', async () => {
+    fs.writeFileSync(
+      path.join(root, 'pages/child-a.vue'),
+      '<template><div>A</div></template><style>h1 { color: red; }</style>',
+    )
+    fs.writeFileSync(
+      path.join(root, 'pages/child-c.vue'),
+      '<template><div>C</div></template><style>h2 { color: blue; }</style>',
+    )
+    fs.writeFileSync(
+      path.join(root, 'pages/child-b.vue'),
+      '<template><div>B</div></template><style>h3 { color: green; }</style>',
+    )
+    fs.writeFileSync(
+      path.join(root, 'pages/parent.vue'),
+      '<template><ChildA /><ChildC /><ChildB /></template><script setup>import ChildA from "./child-a.vue"\nimport ChildC from "./child-c.vue"\nimport ChildB from "./child-b.vue"</script>',
+    )
+
+    await prodBuild(root)
+
+    const manifestPath = path.join(root, 'dist/server', manifestFileName)
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+    const cssList: string[] = manifest.cssMap['pages/parent.vue']
+
+    expect(cssList).toBeDefined()
+    expect(cssList).toHaveLength(3)
+
+    // Order must match depth-first import traversal: child-a, child-c, child-b
+    expect(cssList[0]).toEqual(expect.stringMatching(/child-a/))
+    expect(cssList[1]).toEqual(expect.stringMatching(/child-c/))
+    expect(cssList[2]).toEqual(expect.stringMatching(/child-b/))
+  })
+})

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -60,6 +60,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
          * Recursively traverse static and dynamic dependencies, writing
          * visited state and result in the sets passed through arguments.
          * The values are shared and mutated during recursive calls.
+         * Set retains insertion order so depth-first discovery order is preserved.
          */
         function collectCss(
           fileName: string,

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,0 +1,5 @@
+const cssRE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
+
+export function isCSS(id: string): boolean {
+  return cssRE.test(id)
+}

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -211,6 +211,23 @@ describe('createDevManifest', () => {
     expect(result).toEqual(['/pages/child.vue?vue&type=style&index=0&lang.css'])
   })
 
+  test('getEntryCssIds collects CSS imported in <script setup>', async () => {
+    const code = '<template><div></div></template><script setup>import "./foo.css"</script>'
+    fs.writeFileSync(path.join(root, 'pages/foo.vue'), code)
+    fs.writeFileSync(path.join(root, 'pages/foo.css'), 'h1 { color: red; }')
+
+    const s = await createTestServer()
+    const serverEnv = s.environments.server as RunnableDevEnvironment
+
+    // Load the module via SSR runner to populate the server module graph
+    await serverEnv.runner.import(path.join(root, 'pages/foo.vue'))
+
+    const manifest = createDevManifest(s)
+    const result = await manifest.getEntryCssIds('foo')
+
+    expect(result).toEqual(['/pages/foo.css'])
+  })
+
   test('getEntryCssIds falls back to file parsing when entry is not in module graph', async () => {
     fs.writeFileSync(
       path.join(root, 'pages/foo.vue'),

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -228,6 +228,38 @@ describe('createDevManifest', () => {
     expect(result).toEqual(['/pages/foo.css'])
   })
 
+  test('getEntryCssIds preserves discovery order of standalone CSS and Vue styles', async () => {
+    fs.writeFileSync(
+      path.join(root, 'pages/child-a.vue'),
+      '<template><div></div></template><script setup>const a = 1</script><style>h1 { color: red; }</style>',
+    )
+    fs.writeFileSync(path.join(root, 'pages/middle.css'), 'h2 { color: blue; }')
+    fs.writeFileSync(
+      path.join(root, 'pages/child-b.vue'),
+      '<template><div></div></template><script setup>const b = 1</script><style>h3 { color: green; }</style>',
+    )
+    // parent imports child-a, then middle.css, then child-b — in that order
+    fs.writeFileSync(
+      path.join(root, 'pages/parent.vue'),
+      '<template><ChildA /><ChildB /></template><script setup>import ChildA from "./child-a.vue"\nimport "./middle.css"\nimport ChildB from "./child-b.vue"</script>',
+    )
+
+    const s = await createTestServer()
+    const serverEnv = s.environments.server as RunnableDevEnvironment
+
+    await serverEnv.runner.import(path.join(root, 'pages/parent.vue'))
+
+    const manifest = createDevManifest(s)
+    const result = await manifest.getEntryCssIds('parent')
+
+    // Order must match import discovery: child-a style, middle.css, child-b style
+    expect(result).toEqual([
+      expect.stringMatching(/^\/pages\/child-a\.vue\?vue&type=style&index=0&lang\.css$/),
+      '/pages/middle.css',
+      expect.stringMatching(/^\/pages\/child-b\.vue\?vue&type=style&index=0&lang\.css$/),
+    ])
+  })
+
   test('getEntryCssIds falls back to file parsing when entry is not in module graph', async () => {
     fs.writeFileSync(
       path.join(root, 'pages/foo.vue'),

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -127,8 +127,9 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
         return getComponentCssIds(entryRelativePath)
       }
 
-      // Walk module graph to find all transitively imported .vue files
+      // Walk module graph to find all transitively imported .vue and CSS files
       const vueRelativePaths: string[] = []
+      const cssRelativePaths: string[] = []
       const visited = new Set<string>()
 
       const walk = (mod: EnvironmentModuleNode) => {
@@ -139,6 +140,8 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
 
         if (mod.id.endsWith('.vue')) {
           vueRelativePaths.push(path.relative(root, mod.id))
+        } else if (!mod.id.includes('?vue') && cssRE.test(mod.id)) {
+          cssRelativePaths.push(applyServeBase('/' + path.relative(root, mod.id)))
         }
 
         for (const imported of mod.importedModules) {
@@ -147,9 +150,9 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
       }
       walk(entryMod)
 
-      // Collect CSS from all discovered .vue files
-      const cssArrays = await Promise.all(vueRelativePaths.map((p) => getComponentCssIds(p)))
-      return cssArrays.flat()
+      // Collect CSS from both standalone CSS files and .vue <style> blocks
+      const vueStyleArrays = await Promise.all(vueRelativePaths.map((p) => getComponentCssIds(p)))
+      return [...cssRelativePaths, ...vueStyleArrays.flat()]
     },
   }
 }
@@ -158,6 +161,8 @@ function basePathForDev(base: string): string {
   const baseUrl = new URL(base, 'https://example.com')
   return baseUrl.pathname.replace(/\/$/, '')
 }
+
+const cssRE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/
 
 // these are built-in query parameters so should be ignored
 // if the user happen to add them as attrs

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -128,8 +128,8 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
       }
 
       // Walk module graph to find all transitively imported .vue and CSS files
-      const vueRelativePaths: string[] = []
-      const cssRelativePaths: string[] = []
+      // preserving discovery order
+      const discovered: ({ type: 'css'; id: string } | { type: 'vue'; relativePath: string })[] = []
       const visited = new Set<string>()
 
       const walk = (mod: EnvironmentModuleNode) => {
@@ -139,9 +139,9 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
         visited.add(mod.id)
 
         if (mod.id.endsWith('.vue')) {
-          vueRelativePaths.push(path.relative(root, mod.id))
+          discovered.push({ type: 'vue', relativePath: path.relative(root, mod.id) })
         } else if (!mod.id.includes('?vue') && cssRE.test(mod.id)) {
-          cssRelativePaths.push(applyServeBase('/' + path.relative(root, mod.id)))
+          discovered.push({ type: 'css', id: applyServeBase('/' + path.relative(root, mod.id)) })
         }
 
         for (const imported of mod.importedModules) {
@@ -150,9 +150,13 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
       }
       walk(entryMod)
 
-      // Collect CSS from both standalone CSS files and .vue <style> blocks
-      const vueStyleArrays = await Promise.all(vueRelativePaths.map((p) => getComponentCssIds(p)))
-      return [...cssRelativePaths, ...vueStyleArrays.flat()]
+      // Resolve CSS ids in discovery order
+      const cssIdArrays = await Promise.all(
+        discovered.map((entry) =>
+          entry.type === 'css' ? [entry.id] : getComponentCssIds(entry.relativePath),
+        ),
+      )
+      return cssIdArrays.flat()
     },
   }
 }

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -8,6 +8,7 @@ import { generateComponentId } from '../build/component-id.js'
 import { getVisleConfig } from '../build/config.js'
 import { virtualIslandsBootstrapPath } from '../build/paths.js'
 import { manifestFileName, type ManifestData } from '../build/plugins/manifest.js'
+import { isCSS } from '../core/path.js'
 
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
@@ -140,7 +141,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
 
         if (mod.id.endsWith('.vue')) {
           discovered.push({ type: 'vue', relativePath: path.relative(root, mod.id) })
-        } else if (!mod.id.includes('?vue') && cssRE.test(mod.id)) {
+        } else if (!mod.id.includes('?vue') && isCSS(mod.id)) {
           discovered.push({ type: 'css', id: applyServeBase('/' + path.relative(root, mod.id)) })
         }
 
@@ -165,8 +166,6 @@ function basePathForDev(base: string): string {
   const baseUrl = new URL(base, 'https://example.com')
   return baseUrl.pathname.replace(/\/$/, '')
 }
-
-const cssRE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/
 
 // these are built-in query parameters so should be ignored
 // if the user happen to add them as attrs

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -1,5 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Dev Server SSR > 'CSS import in script' 1`] = `
+<link
+  rel="stylesheet"
+  href="/styles/imported.css"
+>
+<div>
+  <h2>
+    CSS Import Page
+  </h2>
+</div>
+`;
+
 exports[`Dev Server SSR > 'CSS modules' 1`] = `
 <link
   rel="stylesheet"
@@ -470,6 +482,7 @@ declare module 'visle' {
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>
     'with-css-src-alias': ComponentProps<typeof import('./pages/with-css-src-alias.vue')['default']>
     'with-css-module': ComponentProps<typeof import('./pages/with-css-module.vue')['default']>
+    'with-css-import': ComponentProps<typeof import('./pages/with-css-import.vue')['default']>
     'with-barrel-import': ComponentProps<typeof import('./pages/with-barrel-import.vue')['default']>
     'static': ComponentProps<typeof import('./pages/static.vue')['default']>
     'non-ascii-テスト': ComponentProps<typeof import('./pages/non-ascii-テスト.vue')['default']>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -1,5 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Production Build SSR > 'CSS import in script' 1`] = `
+<link
+  rel="stylesheet"
+  href="/assets/with-css-import-[hash].css"
+>
+<div>
+  <h2>
+    CSS Import Page
+  </h2>
+</div>
+`;
+
 exports[`Production Build SSR > 'CSS modules' 1`] = `
 <link
   rel="stylesheet"
@@ -454,6 +466,7 @@ exports[`Production Build SSR > Build output files 1`] = `
   "assets/named-import-[hash].js",
   "assets/vue.runtime.esm-bundler-[hash].js",
   "assets/with-css-[hash].css",
+  "assets/with-css-import-[hash].css",
   "assets/with-css-module-[hash].css",
   "assets/with-css-src-[hash].css",
   "assets/with-css-src-alias-[hash].css",
@@ -472,6 +485,9 @@ exports[`Production Build SSR > Build output files 2`] = `
     "pages/non-ascii-テスト.vue": [],
     "pages/static.vue": [],
     "pages/with-barrel-import.vue": [],
+    "pages/with-css-import.vue": [
+      "assets/with-css-import-[hash].css",
+    ],
     "pages/with-css-module.vue": [
       "assets/with-css-module-[hash].css",
     ],
@@ -552,6 +568,7 @@ declare module 'visle' {
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>
     'with-css-src-alias': ComponentProps<typeof import('./pages/with-css-src-alias.vue')['default']>
     'with-css-module': ComponentProps<typeof import('./pages/with-css-module.vue')['default']>
+    'with-css-import': ComponentProps<typeof import('./pages/with-css-import.vue')['default']>
     'with-barrel-import': ComponentProps<typeof import('./pages/with-barrel-import.vue')['default']>
     'static': ComponentProps<typeof import('./pages/static.vue')['default']>
     'non-ascii-テスト': ComponentProps<typeof import('./pages/non-ascii-テスト.vue')['default']>

--- a/test/fixtures/pages/with-css-import.vue
+++ b/test/fixtures/pages/with-css-import.vue
@@ -1,0 +1,10 @@
+<script setup>
+// eslint-disable-next-line no-unassigned-import
+import '../styles/imported.css'
+</script>
+
+<template>
+  <div>
+    <h2>CSS Import Page</h2>
+  </div>
+</template>

--- a/test/fixtures/styles/imported.css
+++ b/test/fixtures/styles/imported.css
@@ -1,0 +1,3 @@
+h2 {
+  color: blue;
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,6 +36,7 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'Island with barrel import', component: 'with-barrel-import' },
   { name: 'Shared CSS common chunk', component: 'with-shared-css' },
   { name: 'Dynamic import shared CSS', component: 'with-dynamic-shared-css' },
+  { name: 'CSS import in script', component: 'with-css-import' },
 ]
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSS imports referenced from components (including via script setup) are now detected and included, preserving discovery order so standalone CSS and component styles appear in depth-first order.

* **New Features**
  * Improved CSS discovery in development so transitively imported CSS is collected and ordered consistently.

* **Tests**
  * Added tests validating CSS import detection and that CSS ordering is preserved in dev and production manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->