### PR TITLE
ci: run tests on both Ubuntu and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
         run: pnpm build
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add a matrix strategy to the CI test job to run on both `ubuntu-latest` and `windows-latest`

## Test plan
- [ ] Verify CI runs test jobs on both Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test coverage to run across multiple operating systems (Ubuntu and Windows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->