### PR TITLE
feat: introduce branded path types and module-id utilities to support windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
         run: pnpm build
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 

--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -1,12 +1,16 @@
 import { describe, test, expect } from 'vitest'
 
+import { asAbs } from '../core/path.ts'
 import { generateEntryTypesCode } from './generate.ts'
 
 describe('generateEntryTypesCode', () => {
   test('generates module augmentation with component entries', () => {
-    const entryDir = '/project/pages'
-    const root = '/project'
-    const componentIds = ['/project/pages/static.vue', '/project/pages/with-props.vue']
+    const entryDir = asAbs('/project/pages')
+    const root = asAbs('/project')
+    const componentIds = [
+      asAbs('/project/pages/static.vue'),
+      asAbs('/project/pages/with-props.vue'),
+    ]
 
     const result = generateEntryTypesCode(entryDir, root, componentIds)
 
@@ -19,9 +23,9 @@ describe('generateEntryTypesCode', () => {
   })
 
   test('handles nested components', () => {
-    const entryDir = '/project/pages'
-    const root = '/project'
-    const componentIds = ['/project/pages/nested/index.vue']
+    const entryDir = asAbs('/project/pages')
+    const root = asAbs('/project')
+    const componentIds = [asAbs('/project/pages/nested/index.vue')]
 
     const result = generateEntryTypesCode(entryDir, root, componentIds)
 
@@ -31,7 +35,7 @@ describe('generateEntryTypesCode', () => {
   })
 
   test('handles empty component list', () => {
-    const result = generateEntryTypesCode('/project/pages', '/project', [])
+    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [])
 
     expect(result).toContain("declare module 'visle'")
     expect(result).toContain("import type { ComponentProps } from 'visle'")
@@ -39,7 +43,7 @@ describe('generateEntryTypesCode', () => {
   })
 
   test('include empty export', () => {
-    const result = generateEntryTypesCode('/project/pages', '/project', [])
+    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [])
 
     expect(result).toContain('export {}')
   })

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -1,17 +1,18 @@
-import path from 'node:path'
-
-import { normalizePath } from 'vite'
+import { type AbsolutePath, type RelativePath, relative } from '../core/path.js'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
 
 export const componentWrapPrefix = '\0visle:wrap:'
 
-export function generateServerVirtualEntryCode(entryDir: string, componentIds: string[]): string {
+export function generateServerVirtualEntryCode(
+  entryDir: AbsolutePath,
+  componentIds: AbsolutePath[],
+): string {
   const imports = componentIds.map((id, i) => `import _${i} from '${id}'`).join('\n')
 
   const entries = componentIds
     .map((id, i) => {
-      const key = normalizePath(path.relative(entryDir, id).replace(/\.vue$/, ''))
+      const key = relative(entryDir, id).replace(/\.vue$/, '')
       return `  '${key}': _${i}`
     })
     .join(',\n')
@@ -20,15 +21,12 @@ export function generateServerVirtualEntryCode(entryDir: string, componentIds: s
 }
 
 export function generateComponentWrapperCode(
-  filePath: string,
-  componentRelativePath: string,
+  filePath: AbsolutePath,
+  componentRelativePath: RelativePath,
   importedNames: string[],
 ): string {
-  const normalizedFilePath = normalizePath(filePath)
-  const normalizedRelativePath = normalizePath(componentRelativePath)
-
-  const serializedFilePath = JSON.stringify(normalizedFilePath)
-  const serializedRelativePath = JSON.stringify(normalizedRelativePath)
+  const serializedFilePath = JSON.stringify(filePath)
+  const serializedRelativePath = JSON.stringify(componentRelativePath)
 
   const lines = [
     `import { createComponentWrapper } from 'visle/internal'`,
@@ -52,14 +50,14 @@ export function generateComponentWrapperCode(
 }
 
 export function generateEntryTypesCode(
-  entryDir: string,
-  root: string,
-  componentIds: string[],
+  entryDir: AbsolutePath,
+  root: AbsolutePath,
+  componentIds: AbsolutePath[],
 ): string {
   const entries = componentIds
     .map((id) => {
-      const key = normalizePath(path.relative(entryDir, id).replace(/\.vue$/, ''))
-      const importPath = normalizePath(path.relative(root, id))
+      const key = relative(entryDir, id).replace(/\.vue$/, '')
+      const importPath = relative(root, id)
       return `    '${key}': ComponentProps<typeof import('./${importPath}')['default']>`
     })
     .join('\n')

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import { createObjectProperty, createSimpleExpression } from '@vue/compiler-core'
 import type { Plugin } from 'vite'
 
+import { asAbs, join, resolve } from '../core/path.js'
 import { generateComponentId } from './component-id.js'
 import { VisleConfig, defaultConfig, setVisleConfig } from './config.js'
 import { serverVirtualEntryId } from './generate.js'
@@ -39,8 +40,8 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
     config(userConfig) {
       // Get root from user config or default to cwd
-      const root = path.resolve(userConfig.root ?? process.cwd())
-      const entryDir = path.resolve(root, resolvedConfig.entryDir)
+      const root = asAbs(path.resolve(userConfig.root ?? process.cwd()))
+      const entryDir = resolve(root, resolvedConfig.entryDir)
 
       return {
         environments: {
@@ -92,12 +93,12 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             await builder.build(builder.environments.islands!)
 
             // Write manifest and type definition files after all builds
-            const serverOutDir = path.resolve(root, resolvedConfig.serverOutDir)
+            const serverOutDir = resolve(root, resolvedConfig.serverOutDir)
             await fs.mkdir(serverOutDir, { recursive: true })
 
             await Promise.all([
               fs.writeFile(
-                path.join(serverOutDir, manifestFileName),
+                join(serverOutDir, manifestFileName),
                 JSON.stringify(getManifestData(), null, 2),
               ),
               generateEntryTypes(),

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { globSync } from 'glob'
 
-import { type AbsolutePath, asAbs, asRel, resolve } from '../core/path.js'
+import { type AbsolutePath, asAbs, asRel, join, resolve } from '../core/path.js'
 import { componentWrapPrefix } from './generate.js'
 
 // -----------------------------
@@ -29,7 +29,7 @@ export const islandsBootstrapPath = resolve(
  */
 export function resolvePattern(pattern: string | string[], root: AbsolutePath): AbsolutePath[] {
   if (typeof pattern === 'string') {
-    return globSync(path.join(root, pattern)).map(asAbs)
+    return globSync(join(root, pattern)).map(asAbs)
   }
 
   return pattern.flatMap((p) => resolvePattern(p, root))

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -3,20 +3,21 @@ import path from 'node:path'
 
 import { globSync } from 'glob'
 
+import { type AbsolutePath, asAbs, asRel, resolve } from '../core/path.js'
 import { componentWrapPrefix } from './generate.js'
 
 // -----------------------------
 // Custom Element Paths
 // -----------------------------
 export const virtualIslandsBootstrapPath = '/@visle/bootstrap'
-export const islandsBootstrapPath = path.resolve(
+export const islandsBootstrapPath = resolve(
   // In Deno, import.meta.dirname can be undefined (in https module).
   // Just casting it to string for now.
-  import.meta.dirname as string,
+  asAbs(import.meta.dirname as string),
 
   // The extension can be different between environments.
   // e.g. in testing env, it is `.ts` while in production it is `.js`.
-  `../client/custom-element${path.extname(import.meta.url)}`,
+  asRel(`../client/custom-element${path.extname(import.meta.url)}`),
 )
 
 // -----------------------------
@@ -26,9 +27,9 @@ export const islandsBootstrapPath = path.resolve(
 /**
  * Resolves glob patterns to find files
  */
-export function resolvePattern(pattern: string | string[], root: string): string[] {
+export function resolvePattern(pattern: string | string[], root: AbsolutePath): AbsolutePath[] {
   if (typeof pattern === 'string') {
-    return globSync(path.join(root, pattern))
+    return globSync(path.join(root, pattern)).map(asAbs)
   }
 
   return pattern.flatMap((p) => resolvePattern(p, root))
@@ -78,23 +79,26 @@ export function parseId(id: string): {
 /**
  * Resolves paths for all server components
  */
-export function resolveServerComponentIds(entryDir: string): string[] {
+export function resolveServerComponentIds(entryDir: AbsolutePath): AbsolutePath[] {
   return resolvePattern('/**/*.vue', entryDir)
 }
 
 /**
  * Resolves the path for a component in development mode
  */
-export function resolveDevComponentPath(entryDir: string, componentPath: string): string {
-  return path.resolve(entryDir, `${componentPath}.vue`)
+export function resolveDevComponentPath(
+  entryDir: AbsolutePath,
+  componentPath: string,
+): AbsolutePath {
+  return resolve(entryDir, `${componentPath}.vue`)
 }
 
 /**
  * Resolves the path to the server dist directory
  */
-export function resolveServerDistPath(serverOutDir: string): string {
-  const mjsPath = path.resolve(serverOutDir, 'server-entry.mjs')
-  const jsPath = path.resolve(serverOutDir, 'server-entry.js')
+export function resolveServerDistPath(serverOutDir: AbsolutePath): AbsolutePath {
+  const mjsPath = resolve(serverOutDir, 'server-entry.mjs')
+  const jsPath = resolve(serverOutDir, 'server-entry.js')
 
   if (fs.existsSync(mjsPath)) {
     return mjsPath

--- a/src/build/plugins/dev-style-ssr.ts
+++ b/src/build/plugins/dev-style-ssr.ts
@@ -5,7 +5,8 @@
 
 import type { Plugin } from 'vite'
 
-import { isCSS } from '../../core/path.js'
+import { isCSS } from '../../core/module-id.js'
+import { type AbsolutePath, asAbs } from '../../core/path.js'
 
 /**
  * Development-only plugin that removes server-rendered `<link>` style tags
@@ -13,7 +14,7 @@ import { isCSS } from '../../core/path.js'
  * preventing duplicate styles during development.
  */
 export function devStyleSSRPlugin(): Plugin {
-  let root: string
+  let root: AbsolutePath
 
   return {
     name: 'visle:dev-style-ssr',
@@ -21,7 +22,7 @@ export function devStyleSSRPlugin(): Plugin {
     enforce: 'post',
 
     configResolved(config) {
-      root = config.root
+      root = asAbs(config.root)
     },
 
     transform(code, id) {

--- a/src/build/plugins/entry-types.test.ts
+++ b/src/build/plugins/entry-types.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises'
 import type { ResolvedConfig, ViteDevServer } from 'vite'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 
+import { asAbs } from '../../core/path.ts'
 import { defaultConfig } from '../config.ts'
 import { resolveServerComponentIds } from '../paths.ts'
 import { entryTypesPlugin } from './entry-types.ts'
@@ -53,7 +54,7 @@ describe('entryTypesPlugin', () => {
     const { plugin } = createPlugin()
     const watcher = createWatcher()
 
-    vi.mocked(resolveServerComponentIds).mockReturnValue(['/project/pages/Index.vue'])
+    vi.mocked(resolveServerComponentIds).mockReturnValue([asAbs('/project/pages/Index.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -68,7 +69,7 @@ describe('entryTypesPlugin', () => {
   test('generates dts via generate() for build', async () => {
     const { generate } = createPlugin()
 
-    vi.mocked(resolveServerComponentIds).mockReturnValue(['/project/pages/Index.vue'])
+    vi.mocked(resolveServerComponentIds).mockReturnValue([asAbs('/project/pages/Index.vue')])
 
     await generate()
 
@@ -83,7 +84,7 @@ describe('entryTypesPlugin', () => {
     const { plugin } = createPlugin()
     const watcher = createWatcher()
 
-    vi.mocked(resolveServerComponentIds).mockReturnValue(['/project/pages/New.vue'])
+    vi.mocked(resolveServerComponentIds).mockReturnValue([asAbs('/project/pages/New.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -103,8 +104,8 @@ describe('entryTypesPlugin', () => {
     const watcher = createWatcher()
 
     vi.mocked(resolveServerComponentIds)
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
-      .mockReturnValueOnce(['/project/pages/Index.vue', '/project/pages/New.vue'])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue'), asAbs('/project/pages/New.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -126,8 +127,8 @@ describe('entryTypesPlugin', () => {
     const watcher = createWatcher()
 
     vi.mocked(resolveServerComponentIds)
-      .mockReturnValueOnce(['/project/pages/Index.vue', '/project/pages/Old.vue'])
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue'), asAbs('/project/pages/Old.vue')])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -143,8 +144,8 @@ describe('entryTypesPlugin', () => {
     const watcher = createWatcher()
 
     vi.mocked(resolveServerComponentIds)
-      .mockReturnValueOnce(['/project/pages/Index.vue', '/project/pages/Old.vue'])
-      .mockReturnValueOnce(['/project/pages/Index.vue', '/project/pages/New.vue'])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue'), asAbs('/project/pages/Old.vue')])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue'), asAbs('/project/pages/New.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -163,8 +164,8 @@ describe('entryTypesPlugin', () => {
     const watcher = createWatcher()
 
     vi.mocked(resolveServerComponentIds)
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -181,8 +182,8 @@ describe('entryTypesPlugin', () => {
     const watcher = createWatcher()
 
     vi.mocked(resolveServerComponentIds)
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
-      .mockReturnValueOnce(['/project/pages/Index.vue'])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
+      .mockReturnValueOnce([asAbs('/project/pages/Index.vue')])
 
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
@@ -208,7 +209,7 @@ describe('entryTypesPlugin', () => {
   test('uses custom dts path', async () => {
     const { generate } = createPlugin('types/visle.d.ts')
 
-    vi.mocked(resolveServerComponentIds).mockReturnValue(['/project/pages/Index.vue'])
+    vi.mocked(resolveServerComponentIds).mockReturnValue([asAbs('/project/pages/Index.vue')])
 
     await generate()
 

--- a/src/build/plugins/entry-types.ts
+++ b/src/build/plugins/entry-types.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises'
-import path from 'node:path'
 
 import type { Plugin } from 'vite'
 
+import { type AbsolutePath, asAbs, resolve } from '../../core/path.js'
 import type { ResolvedVisleConfig } from '../config.js'
 import { generateEntryTypesCode } from '../generate.js'
 import { resolveServerComponentIds } from '../paths.js'
@@ -23,9 +23,9 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
     }
   }
 
-  let root: string
-  let entryRoot: string
-  let dtsPath: string
+  let root: AbsolutePath
+  let entryRoot: AbsolutePath
+  let dtsPath: AbsolutePath
   let lastContent: string | undefined
 
   async function generateAndWrite(): Promise<void> {
@@ -53,9 +53,9 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
     name: 'visle:entry-types',
 
     configResolved(viteConfig) {
-      root = viteConfig.root
-      entryRoot = path.resolve(root, config.entryDir)
-      dtsPath = path.resolve(root, config.dts!)
+      root = asAbs(viteConfig.root)
+      entryRoot = resolve(root, config.entryDir)
+      dtsPath = resolve(root, config.dts!)
     },
 
     async configureServer(server) {

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -1,7 +1,6 @@
-import path from 'node:path'
+import type { Plugin } from 'vite'
 
-import { normalizePath, Plugin } from 'vite'
-
+import { asAbs, relative } from '../../core/path.js'
 import type { ResolvedVisleConfig } from '../config.js'
 import { islandsBootstrapPath } from '../paths.js'
 
@@ -39,8 +38,8 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
     },
 
     generateBundle(_options, bundle) {
-      const envName = this.environment?.name
-      const root = this.environment?.config.root ?? ''
+      const envName = this.environment.name
+      const root = asAbs(this.environment.config.root)
 
       if (envName === 'style') {
         const envCssMap = new Map<string, string[]>()
@@ -93,7 +92,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
 
           for (const moduleId of chunk.moduleIds) {
             if (this.getModuleInfo(moduleId)?.isEntry) {
-              const relativePath = normalizePath(path.relative(root, moduleId))
+              const relativePath = relative(root, asAbs(moduleId))
               const collected = collectCss(chunk.fileName)
               envCssMap.set(relativePath, Array.from(collected))
             }
@@ -134,7 +133,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
           // (e.g., barrel files merged with their re-export targets by Rollup)
           for (const moduleId of chunk.moduleIds) {
             if (this.getModuleInfo(moduleId)?.isEntry) {
-              const moduleRelativePath = normalizePath(path.relative(root, moduleId))
+              const moduleRelativePath = relative(root, asAbs(moduleId))
               envJsMap.set(moduleRelativePath, chunk.fileName)
             }
           }

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -1,8 +1,7 @@
-import path from 'node:path'
-
 import type { Plugin, ResolvedConfig } from 'vite'
 import { parse } from 'vue/compiler-sfc'
 
+import { asAbs, relative } from '../../core/path.js'
 import { generateComponentWrapperCode, componentWrapPrefix } from '../generate.js'
 import { parseId } from '../paths.js'
 import { buildImportMap, findVClientElements } from '../sfc-analysis.js'
@@ -87,10 +86,12 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
       const { prefix, fileName, query } = parseId(id)
 
       if (prefix === componentWrapPrefix) {
-        const componentRelativePath = path.relative(viteConfig.root, fileName)
+        const root = asAbs(viteConfig.root)
+        const absFileName = asAbs(fileName)
+        const componentRelativePath = relative(root, absFileName)
         const importedNames = query.names ?? []
 
-        return generateComponentWrapperCode(fileName, componentRelativePath, importedNames)
+        return generateComponentWrapperCode(absFileName, componentRelativePath, importedNames)
       }
     },
 

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -1,7 +1,6 @@
-import path from 'node:path'
-
 import { Plugin } from 'vite'
 
+import { type AbsolutePath, asAbs, resolve } from '../../core/path.js'
 import { ResolvedVisleConfig } from '../config.js'
 import { generateServerVirtualEntryCode, serverVirtualEntryId } from '../generate.js'
 import {
@@ -15,13 +14,13 @@ import {
  * per environment (style, islands, server, dev client).
  */
 export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
-  let entryRoot: string
+  let entryRoot: AbsolutePath
 
   return {
     name: 'visle:virtual-file',
 
     configResolved(resolvedConfig) {
-      entryRoot = path.join(resolvedConfig.root, config.entryDir)
+      entryRoot = resolve(asAbs(resolvedConfig.root), config.entryDir)
     },
 
     resolveId(id) {

--- a/src/core/module-id.test.ts
+++ b/src/core/module-id.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCSS } from './module-id.js'
+
+describe('isCSS', () => {
+  it.each(['.css', '.scss', '.sass', '.postcss', '.pcss', '.less', '.stylus', '.styl'])(
+    'matches %s extension',
+    (ext) => {
+      expect(isCSS(`/foo/bar${ext}`)).toBe(true)
+    },
+  )
+
+  it('matches with query string', () => {
+    expect(isCSS('/foo/bar.css?used')).toBe(true)
+  })
+
+  it('does not match non-CSS extension', () => {
+    expect(isCSS('/foo/bar.ts')).toBe(false)
+    expect(isCSS('/foo/bar.vue')).toBe(false)
+    expect(isCSS('/foo/bar.js')).toBe(false)
+  })
+
+  it('does not match partial extension', () => {
+    expect(isCSS('/foo/bar.cssx')).toBe(false)
+  })
+
+  it('matches Vue style block module id with lang query', () => {
+    expect(isCSS('/foo/bar.vue?vue&type=style&index=0&lang.css')).toBe(true)
+    expect(isCSS('/foo/bar.vue?vue&type=style&index=0&scoped=abc123&lang.scss')).toBe(true)
+  })
+
+  it('does not match Vue style block module id without lang query', () => {
+    expect(isCSS('/foo/bar.vue?vue&type=style&index=0')).toBe(false)
+  })
+})

--- a/src/core/module-id.ts
+++ b/src/core/module-id.ts
@@ -1,0 +1,5 @@
+const cssRE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
+
+export function isCSS(id: string): boolean {
+  return cssRE.test(id)
+}

--- a/src/core/path.test.ts
+++ b/src/core/path.test.ts
@@ -63,6 +63,16 @@ describe('resolve', () => {
     const result = resolve(asAbs('/foo'), 'bar', 'baz')
     expect(result).toBe('/foo/bar/baz')
   })
+
+  it.skipIf(process.platform !== 'win32')('preserves drive letter from base', () => {
+    const result = resolve(asAbs('C:/foo'), 'bar')
+    expect(result).toBe('C:/foo/bar')
+  })
+
+  it.skipIf(process.platform !== 'win32')('preserves drive letter from segment', () => {
+    const result = resolve(asAbs('/foo'), 'D:/bar')
+    expect(result).toBe('D:/bar')
+  })
 })
 
 describe('join', () => {

--- a/src/core/path.test.ts
+++ b/src/core/path.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { asAbs, asRel, dirname, join, resolve, relative } from './path.js'
+
+describe('asAbs', () => {
+  it('accepts absolute path', () => {
+    const result = asAbs('/foo/bar')
+    expect(result).toBe('/foo/bar')
+  })
+
+  it('throws for relative path', () => {
+    expect(() => asAbs('foo/bar')).toThrow('Expected absolute path')
+  })
+
+  it('normalizes backslashes', () => {
+    const result = asAbs('\\foo\\bar\\baz')
+    expect(result).toBe('/foo/bar/baz')
+  })
+
+  it('accepts Windows drive letter path', () => {
+    const result = asAbs('C:/foo/bar')
+    expect(result).toBe('C:/foo/bar')
+  })
+
+  it('normalizes Windows backslash path', () => {
+    const result = asAbs('C:\\foo\\bar')
+    expect(result).toBe('C:/foo/bar')
+  })
+})
+
+describe('asRel', () => {
+  it('accepts relative path', () => {
+    const result = asRel('foo/bar')
+    expect(result).toBe('foo/bar')
+  })
+
+  it('throws for absolute path', () => {
+    expect(() => asRel('/foo/bar')).toThrow('Expected relative path')
+  })
+
+  it('throws for Windows drive letter path', () => {
+    expect(() => asRel('C:/foo/bar')).toThrow('Expected relative path')
+  })
+
+  it('normalizes backslashes', () => {
+    const result = asRel('foo\\bar\\baz')
+    expect(result).toBe('foo/bar/baz')
+  })
+})
+
+describe('resolve', () => {
+  it('resolves to absolute path', () => {
+    const result = resolve(asAbs('/foo'), 'bar')
+    expect(result).toBe('/foo/bar')
+  })
+
+  it('resolves .. segments', () => {
+    const result = resolve(asAbs('/foo/bar'), '../baz')
+    expect(result).toBe('/foo/baz')
+  })
+
+  it('resolves multiple segments', () => {
+    const result = resolve(asAbs('/foo'), 'bar', 'baz')
+    expect(result).toBe('/foo/bar/baz')
+  })
+})
+
+describe('join', () => {
+  it('joins absolute paths', () => {
+    const base = asAbs('/foo/bar')
+    const result = join(base, 'baz', 'qux.ts')
+    expect(result).toBe('/foo/bar/baz/qux.ts')
+  })
+
+  it('joins relative paths', () => {
+    const base = asRel('foo/bar')
+    const result = join(base, 'baz')
+    expect(result).toBe('foo/bar/baz')
+  })
+
+  it('normalizes .. segments', () => {
+    const base = asAbs('/foo/bar')
+    const result = join(base, '..', 'baz')
+    expect(result).toBe('/foo/baz')
+  })
+})
+
+describe('relative', () => {
+  it('computes relative path', () => {
+    const result = relative(asAbs('/foo/bar'), asAbs('/foo/bar/baz/qux.ts'))
+    expect(result).toBe('baz/qux.ts')
+  })
+
+  it('computes relative path with ..', () => {
+    const result = relative(asAbs('/foo/bar'), asAbs('/foo/baz/qux.ts'))
+    expect(result).toBe('../baz/qux.ts')
+  })
+})
+
+describe('dirname', () => {
+  it('returns dirname of absolute path', () => {
+    const result = dirname(asAbs('/foo/bar/baz.ts'))
+    expect(result).toBe('/foo/bar')
+  })
+
+  it('returns dirname of relative path', () => {
+    const result = dirname(asRel('foo/bar/baz.ts'))
+    expect(result).toBe('foo/bar')
+  })
+})

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,5 +1,55 @@
-const cssRE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
+import path from 'node:path'
 
-export function isCSS(id: string): boolean {
-  return cssRE.test(id)
+export type AbsolutePath = string & { readonly __brand: 'AbsolutePath' }
+export type RelativePath = string & { readonly __brand: 'RelativePath' }
+
+/**
+ * Normalize backslashes to forward slashes
+ * @internal
+ */
+function normalizePosix(p: string): string {
+  return p.replace(/\\/g, '/')
+}
+
+/**
+ * Matches `/` or drive letter like `C:/`
+ */
+function isAbsolute(p: string): boolean {
+  return p.startsWith('/') || /^[a-zA-Z]:\//.test(p)
+}
+
+export function asAbs(value: string): AbsolutePath {
+  const normalized = normalizePosix(value)
+  if (!isAbsolute(normalized)) {
+    throw new Error(`Expected absolute path, got: ${value}`)
+  }
+  return normalized as AbsolutePath
+}
+
+export function asRel(value: string): RelativePath {
+  const normalized = normalizePosix(value)
+  if (isAbsolute(normalized)) {
+    throw new Error(`Expected relative path, got: ${value}`)
+  }
+  return normalized as RelativePath
+}
+
+export function resolve(base: AbsolutePath, ...segments: string[]): AbsolutePath {
+  return normalizePosix(path.resolve(base, ...segments)) as AbsolutePath
+}
+
+export function join(base: AbsolutePath, ...segments: string[]): AbsolutePath
+export function join(base: RelativePath, ...segments: string[]): RelativePath
+export function join(base: string, ...segments: string[]): string {
+  return normalizePosix(path.join(base, ...segments))
+}
+
+export function relative(from: AbsolutePath, to: AbsolutePath): RelativePath {
+  return normalizePosix(path.relative(from, to)) as RelativePath
+}
+
+export function dirname(p: AbsolutePath): AbsolutePath
+export function dirname(p: RelativePath): RelativePath
+export function dirname(p: string): string {
+  return normalizePosix(path.dirname(p))
 }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -11,6 +11,12 @@ function normalizePosix(p: string): string {
   return p.replace(/\\/g, '/')
 }
 
+const driveLetterRE = /^[a-zA-Z]:/
+
+function hasDriveLetter(p: string): boolean {
+  return driveLetterRE.test(p)
+}
+
 /**
  * Matches `/` or drive letter like `C:/`
  */
@@ -35,7 +41,19 @@ export function asRel(value: string): RelativePath {
 }
 
 export function resolve(base: AbsolutePath, ...segments: string[]): AbsolutePath {
-  return normalizePosix(path.resolve(base, ...segments)) as AbsolutePath
+  const result = normalizePosix(path.resolve(base, ...segments))
+
+  // On Windows, path.resolve prepends the current drive letter when inputs
+  // don't include one. Strip it to keep results consistent with inputs.
+  if (
+    process.platform === 'win32' &&
+    hasDriveLetter(result) &&
+    [base, ...segments].every((s) => !hasDriveLetter(s))
+  ) {
+    return result.replace(driveLetterRE, '') as AbsolutePath
+  }
+
+  return result as AbsolutePath
 }
 
 export function join(base: AbsolutePath, ...segments: string[]): AbsolutePath

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -1,10 +1,9 @@
-import path from 'node:path'
-
 import connect from 'connect'
 import { Connect, createServer, InlineConfig, RunnableDevEnvironment, ViteDevServer } from 'vite'
 
 import { getVisleConfig } from '../build/config.js'
 import { resolveDevComponentPath } from '../build/paths.js'
+import { asAbs, resolve } from '../core/path.js'
 import { createDevManifest, RuntimeManifest } from './manifest.js'
 import { RenderLoader } from './render.js'
 
@@ -61,7 +60,7 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
       const visleConfig = getVisleConfig(devServer.config)
 
       const modulePath = resolveDevComponentPath(
-        path.join(devServer.config.root, visleConfig.entryDir),
+        resolve(asAbs(devServer.config.root), visleConfig.entryDir),
         componentPath,
       )
 

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { visle } from '../build/index.ts'
 import { virtualIslandsBootstrapPath } from '../build/paths.ts'
 import { manifestFileName } from '../build/plugins/manifest.ts'
+import { asAbs } from '../core/path.ts'
 import { createDevManifest, loadManifest } from './manifest.ts'
 
 const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/server')
@@ -300,7 +301,7 @@ describe('loadManifest', () => {
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(root)
+    const manifest = await loadManifest(asAbs(root))
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe('/foo-1234.js')
@@ -311,7 +312,7 @@ describe('loadManifest', () => {
       jsMap: {},
     })
 
-    const manifest = await loadManifest(root)
+    const manifest = await loadManifest(asAbs(root))
 
     await expect(manifest.getClientImportId('src/foo.vue')).rejects.toThrow(
       'src/foo.vue not found in manifest JS map',
@@ -323,7 +324,7 @@ describe('loadManifest', () => {
       cssMap: { 'pages/foo.vue': ['foo-1234.css'] },
     })
 
-    const manifest = await loadManifest(root)
+    const manifest = await loadManifest(asAbs(root))
     const result = await manifest.getEntryCssIds('foo')
 
     expect(result).toEqual(['/foo-1234.css'])
@@ -338,7 +339,7 @@ describe('loadManifest', () => {
       jsMap: { 'src/foo.vue': 'foo-1234.js' },
     })
 
-    const manifest = await loadManifest(root)
+    const manifest = await loadManifest(asAbs(root))
     const result = await manifest.getClientImportId('src/foo.vue')
 
     expect(result).toBe(expected)
@@ -350,7 +351,7 @@ describe('loadManifest', () => {
       cssMap: { 'views/index.vue': ['index-1234.css'] },
     })
 
-    const manifest = await loadManifest(root)
+    const manifest = await loadManifest(asAbs(root))
     const result = await manifest.getEntryCssIds('index')
 
     expect(result).toEqual(['/index-1234.css'])

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises'
-import path from 'node:path'
 
 import type { EnvironmentModuleNode, RunnableDevEnvironment, ViteDevServer } from 'vite'
 import { parse, SFCBlock } from 'vue/compiler-sfc'
@@ -8,7 +7,8 @@ import { generateComponentId } from '../build/component-id.js'
 import { getVisleConfig } from '../build/config.js'
 import { virtualIslandsBootstrapPath } from '../build/paths.js'
 import { manifestFileName, type ManifestData } from '../build/plugins/manifest.js'
-import { isCSS } from '../core/path.js'
+import { isCSS } from '../core/module-id.js'
+import { type AbsolutePath, asAbs, dirname, join, resolve, relative, asRel } from '../core/path.js'
 
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
@@ -19,8 +19,8 @@ export interface RuntimeManifest {
 /**
  * Loads the manifest file from serverOutDir for production SSR.
  */
-export async function loadManifest(serverOutDir: string): Promise<RuntimeManifest> {
-  const manifestPath = path.join(serverOutDir, manifestFileName)
+export async function loadManifest(serverOutDir: AbsolutePath): Promise<RuntimeManifest> {
+  const manifestPath = join(serverOutDir, manifestFileName)
 
   const data: ManifestData = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
   const basePath = data.base.replace(/\/$/, '')
@@ -51,7 +51,8 @@ export async function loadManifest(serverOutDir: string): Promise<RuntimeManifes
  */
 export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
   const serverEnv = devServer.environments.server as RunnableDevEnvironment
-  const { root, base } = devServer.config
+  const root = asAbs(devServer.config.root)
+  const { base } = devServer.config
   const { entryDir } = getVisleConfig(devServer.config)
 
   // Normalize origin value
@@ -63,7 +64,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
   }
 
   async function getComponentCssIds(componentRelativePath: string): Promise<string[]> {
-    const absPath = path.resolve(root, componentRelativePath)
+    const absPath = resolve(root, componentRelativePath)
 
     if (!absPath.endsWith('.vue')) {
       return []
@@ -84,14 +85,13 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
         if (!style.src) {
           stylePath = `/${componentRelativePath}`
         } else if (style.src.startsWith('.')) {
-          stylePath =
-            '/' +
-            path.posix.normalize(path.posix.join(path.dirname(componentRelativePath), style.src))
+          const componentDir = dirname(asRel(componentRelativePath))
+          stylePath = '/' + join(componentDir, style.src)
         } else {
           const result = await serverEnv.pluginContainer.resolveId(style.src, absPath)
           const resolved = result?.id
           if (resolved) {
-            stylePath = '/' + path.relative(root, resolved)
+            stylePath = '/' + relative(root, asAbs(resolved))
           } else {
             stylePath = '/' + style.src
           }
@@ -120,7 +120,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {
       const entryRelativePath = `${entryDir}/${componentPath}.vue`
-      const entryAbsPath = path.resolve(root, entryRelativePath)
+      const entryAbsPath = resolve(root, entryRelativePath)
 
       const entryMod = serverEnv.moduleGraph.getModuleById(entryAbsPath)
       if (!entryMod) {
@@ -140,9 +140,15 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
         visited.add(mod.id)
 
         if (mod.id.endsWith('.vue')) {
-          discovered.push({ type: 'vue', relativePath: path.relative(root, mod.id) })
+          discovered.push({
+            type: 'vue',
+            relativePath: relative(root, asAbs(mod.id)),
+          })
         } else if (!mod.id.includes('?vue') && isCSS(mod.id)) {
-          discovered.push({ type: 'css', id: applyServeBase('/' + path.relative(root, mod.id)) })
+          discovered.push({
+            type: 'css',
+            id: applyServeBase('/' + relative(root, asAbs(mod.id))),
+          })
         }
 
         for (const imported of mod.importedModules) {

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -1,8 +1,11 @@
+import path from 'node:path'
+
 import { Component, createApp } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
 import { defaultConfig } from '../build/config.js'
 import { resolveServerDistPath } from '../build/paths.js'
+import { asAbs } from '../core/path.js'
 import { RuntimeManifest, loadManifest } from './manifest.js'
 import { transformWithRenderContext } from './transform.js'
 
@@ -44,7 +47,7 @@ export function createRender<T extends Record<string, any> = Record<string, any>
 
   let loader: RenderLoader = {
     loadEntry(componentPath) {
-      const serverOutDir = options.serverOutDir ?? defaultConfig.serverOutDir
+      const serverOutDir = asAbs(path.resolve(options.serverOutDir ?? defaultConfig.serverOutDir))
 
       return import(/* @vite-ignore */ resolveServerDistPath(serverOutDir)).then(
         (m) => m.default[componentPath],
@@ -53,7 +56,7 @@ export function createRender<T extends Record<string, any> = Record<string, any>
 
     async getManifest() {
       if (!cachedManifest) {
-        const serverOutDir = options.serverOutDir ?? defaultConfig.serverOutDir
+        const serverOutDir = asAbs(path.resolve(options.serverOutDir ?? defaultConfig.serverOutDir))
         cachedManifest = await loadManifest(serverOutDir)
       }
       return cachedManifest

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Dev Server SSR > 'CSS modules' 1`] = `
   rel="stylesheet"
   href="/pages/with-css-module.vue?vue&type=style&index=0&lang.module.css"
 >
-<div class="_container_[css-module-hash]_2">
+<div class="_container_[css-module-hash]">
   CSS Module
 </div>
 `;

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Production Build SSR > 'CSS modules' 1`] = `
   rel="stylesheet"
   href="/assets/with-css-module-[hash].css"
 >
-<div class="_container_[css-module-hash]_2">
+<div class="_container_[css-module-hash]">
   CSS Module
 </div>
 `;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { createBuilder, mergeConfig, type UserConfig } from 'vite'
 
 import { visle } from '../src/build/index.ts'
+import { asRel } from '../src/core/path.ts'
 import { createDevLoader } from '../src/server/dev.ts'
 import { createRender } from '../src/server/render.ts'
 
@@ -135,5 +136,5 @@ export async function listFiles(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true, recursive: true })
   return entries
     .filter((e) => e.isFile())
-    .map((e) => path.relative(dir, path.join(e.parentPath, e.name)))
+    .map((e) => asRel(path.relative(dir, path.join(e.parentPath, e.name))))
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -116,14 +116,14 @@ export function prodRender(root: string) {
 /**
  * Replace unstable hashes with stable placeholders for snapshot matching.
  * - Vite content hash: "Counter-Cv0abcde.js" -> "Counter-[hash].js"
- * - CSS module class: "_container_184t0_2" -> "_container_[css-module-hash]_2"
+ * - CSS module class: "_container_184t0_2" -> "_container_[css-module-hash]"
  * - Vue scoped attr: "data-v-aa4849be" -> "data-v-[scoped]"
  * - Vue scoped in URL: "scoped=aa4849be" -> "scoped=[scoped]"
  */
 export function normalizeHashes(html: string): string {
   return html
     .replace(/-[A-Za-z0-9_-]{8}\.(js|css|svg)/g, '-[hash].$1')
-    .replace(/(_\w+)_[a-z0-9]{5}_(\d+)/g, '$1_[css-module-hash]_$2')
+    .replace(/(_\w+)_[a-z0-9]{5}_\d+/g, '$1_[css-module-hash]')
     .replace(/(data-v-)[a-f0-9]{8}/g, '$1[scoped]')
     .replace(/(scoped=)[a-f0-9]{8}/g, '$1[scoped]')
     .replace(/(src=)[a-f0-9]{8}/g, '$1[src]')


### PR DESCRIPTION
## Summary
- Introduce branded `AbsolutePath` and `RelativePath` types in `src/core/path.ts` with helper functions (`asAbs`, `asRel`, `resolve`, `join`, `relative`, `dirname`) for type-safe path manipulation
- Extract module ID utilities (CSS detection, etc.) into a dedicated `src/core/module-id.ts` module
- Migrate all path handling across build plugins, server, and manifest code to use the new branded types

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled internal path handling with stronger absolute/relative abstractions for consistent, cross-platform resolution.
* **Bug Fixes / Stability**
  * Standardized path computations across the build and server flows to reduce path-related issues.
* **Tests**
  * Added and expanded unit tests for path utilities and CSS/module detection.
* **Chores**
  * CI updated to run tests on both Linux and Windows for improved platform coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->