### PR TITLE
ci: cache Playwright browsers to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,27 @@ jobs:
 
       - run: pnpm install
 
+      - name: Get Playwright version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      # Cache Playwright browser binaries to avoid downloading them on every run.
+      # This significantly speeds up CI, especially on Windows where install takes several minutes.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Install Playwright browsers and system deps.
+      # On cache hit, browser download is a no-op but Linux still needs system deps installed.
+      # Windows bundles its own deps, so it can skip this step entirely on cache hit.
       - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true' || runner.os == 'Linux'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Test


### PR DESCRIPTION
## Summary
- Cache Playwright browser binaries using `actions/cache` keyed by OS and Playwright version
- Skip install entirely on Windows cache hits (saves ~3 minutes)
- On Linux cache hits, still run `install --with-deps` to ensure system libraries are present

## Test plan
- [ ] Verify CI passes on both ubuntu and windows
- [ ] Verify second run on same Playwright version uses cache and is faster