### PR TITLE
feat: add v-client:visible directive

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import vue from '@vitejs/plugin-vue'
-import { createObjectProperty, createSimpleExpression } from '@vue/compiler-core'
+import { createObjectProperty, createSimpleExpression, NodeTypes } from '@vue/compiler-core'
 import type { Plugin } from 'vite'
 
 import { generateComponentId } from '../core/component-id.js'
@@ -156,14 +156,27 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             // server-transform plugin searches v-client directive to detect
             // island component. Strip v-client directive here to make sure to
             // remove it in all environment.
-            client: () => ({
-              props: [
+            client: (dir) => {
+              const props = [
                 createObjectProperty(
-                  createSimpleExpression('__visle_client__', true),
-                  createSimpleExpression('true', false),
+                  createSimpleExpression('__visle_strategy__', true),
+                  createSimpleExpression(
+                    JSON.stringify(
+                      dir.arg?.type === NodeTypes.SIMPLE_EXPRESSION ? dir.arg.content : 'load',
+                    ),
+                    false,
+                  ),
                 ),
-              ],
-            }),
+              ]
+
+              if (dir.exp) {
+                props.push(
+                  createObjectProperty(createSimpleExpression('__visle_options__', true), dir.exp),
+                )
+              }
+
+              return { props }
+            },
           },
         },
       },

--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -365,4 +365,11 @@ describe('findVClientElements', () => {
     expect(results).toHaveLength(1)
     expect(results[0]!.tag).toBe('div')
   })
+
+  test('finds element with v-client:visible', () => {
+    const children = parseTemplate('<Counter v-client:visible />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0]!.tag).toBe('Counter')
+  })
 })

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -120,7 +120,7 @@ export function buildImportMap(descriptor: SFCDescriptor, id: string): Map<strin
 }
 
 /**
- * Recursively finds elements with v-client:load directive.
+ * Recursively finds elements with v-client:* directive.
  */
 export function findVClientElements(children: TemplateChildNode[]): ElementNode[] {
   const results: ElementNode[] = []

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -135,7 +135,7 @@ export function findVClientElements(children: TemplateChildNode[]): ElementNode[
         prop.type === NodeTypes.DIRECTIVE &&
         prop.name === 'client' &&
         prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
-        prop.arg.content === 'load',
+        (prop.arg.content === 'load' || prop.arg.content === 'visible'),
     )
 
     if (hasVClient) {

--- a/src/client/custom-element.test.ts
+++ b/src/client/custom-element.test.ts
@@ -118,6 +118,96 @@ describe('VueIsland custom element', () => {
     })
   })
 
+  describe('visible strategy', () => {
+    let observeCallback: IntersectionObserverCallback
+    let observeOptions: IntersectionObserverInit | undefined
+    let mockDisconnect: ReturnType<typeof vi.fn>
+    let mockObserve: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockDisconnect = vi.fn()
+      mockObserve = vi.fn()
+
+      class MockIntersectionObserver {
+        constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+          observeCallback = callback
+          observeOptions = options
+        }
+
+        observe = mockObserve
+        disconnect = mockDisconnect
+        unobserve = vi.fn()
+      }
+
+      vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+    })
+
+    test('does not hydrate immediately when strategy is visible', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+      expect(mockObserve).toHaveBeenCalledWith(el.firstElementChild ?? el)
+    })
+
+    test('hydrates when intersection fires', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+
+      // Simulate intersection
+      observeCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+      await flushMicrotasks()
+
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('cleans up observer on disconnect before visible', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      // Disconnect before intersection fires
+      document.body.removeChild(el)
+
+      // Simulate late intersection
+      observeCallback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+    })
+
+    test('passes rootMargin to IntersectionObserver from options attribute', async () => {
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'visible',
+        options: '{"rootMargin":"200px"}',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(observeOptions).toEqual({ rootMargin: '200px' })
+    })
+
+    test('does not pass rootMargin when options attribute is absent', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'visible' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(observeOptions).toBeUndefined()
+    })
+  })
+
   describe('disconnectedCallback', () => {
     test('unmounts the app on disconnect', async () => {
       const el = createIsland({ entry: './test-entry' })

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -4,6 +4,7 @@ import { loadModule } from './load-module.js'
 
 export class VueIsland extends HTMLElement {
   #app: App | null = null
+  #visibilityObserver: IntersectionObserver | null = null
 
   /**
    * Monotonic counter to invalidate stale async work in connectedCallback.
@@ -74,12 +75,14 @@ export class VueIsland extends HTMLElement {
       const observer = new IntersectionObserver(
         (entries) => {
           if (entries.some((e) => e.isIntersecting)) {
+            this.#visibilityObserver = null
             observer.disconnect()
             resolve()
           }
         },
         rootMargin ? { rootMargin } : undefined,
       )
+      this.#visibilityObserver = observer
       // The host element uses display:contents and has no layout box,
       // so observe the first light-DOM child which has actual dimensions.
       observer.observe(this.firstElementChild ?? this)
@@ -88,6 +91,8 @@ export class VueIsland extends HTMLElement {
 
   disconnectedCallback(): void {
     this.#connectToken++
+    this.#visibilityObserver?.disconnect()
+    this.#visibilityObserver = null
     this.#app?.unmount()
     this.#app = null
   }

--- a/src/client/custom-element.ts
+++ b/src/client/custom-element.ts
@@ -37,7 +37,15 @@ export class VueIsland extends HTMLElement {
       return
     }
 
-    const serializedProps = this.getAttribute('serialized-props') ?? '{}'
+    const strategy = this.getAttribute('strategy') ?? 'load'
+
+    if (strategy === 'visible') {
+      await this.#waitForVisible()
+      if (token !== this.#connectToken || !this.isConnected) {
+        return
+      }
+    }
+
     const importedName = this.getAttribute('imported-name') ?? 'default'
 
     const module = await loadModule(entry)
@@ -52,10 +60,30 @@ export class VueIsland extends HTMLElement {
       return
     }
 
-    const parsedProps = tryParseProps(serializedProps)
+    const parsedProps = safeParseObject(this.getAttribute('serialized-props'))
 
     this.#app = createSSRApp(entryComponent, parsedProps)
     this.#app.mount(this)
+  }
+
+  #waitForVisible(): Promise<void> {
+    const rootMargin = safeParseObject(this.getAttribute('options'))?.rootMargin as
+      | string
+      | undefined
+    return new Promise((resolve) => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) {
+            observer.disconnect()
+            resolve()
+          }
+        },
+        rootMargin ? { rootMargin } : undefined,
+      )
+      // The host element uses display:contents and has no layout box,
+      // so observe the first light-DOM child which has actual dimensions.
+      observer.observe(this.firstElementChild ?? this)
+    })
   }
 
   disconnectedCallback(): void {
@@ -66,12 +94,16 @@ export class VueIsland extends HTMLElement {
 }
 
 /**
- * Parse serialized props.
- * Return empty object if parsing is failed or parsed value is not an object.
+ * Parse a JSON string as an object, returning an empty object if
+ * parsing fails or the parsed value is not an object.
  */
-function tryParseProps(serialized: string): Record<string, unknown> {
+function safeParseObject(value: string | null): Record<string, unknown> {
+  if (!value) {
+    return {}
+  }
+
   try {
-    const parsed = JSON.parse(serialized)
+    const parsed = JSON.parse(value)
     return typeof parsed === 'object' && parsed != null ? parsed : {}
   } catch {
     return {}

--- a/src/server/component-wrapper.ts
+++ b/src/server/component-wrapper.ts
@@ -13,15 +13,14 @@ export function createComponentWrapper(
     inheritAttrs: false,
 
     props: {
-      __visle_client__: Boolean,
+      __visle_strategy__: String,
+      __visle_options__: Object,
     },
 
     setup(props, { slots }) {
       const attrs = useAttrs()
 
-      const isIsland = props.__visle_client__
-
-      if (isIsland) {
+      if (props.__visle_strategy__) {
         const context: RenderContext = useSSRContext()!
         const manifest = context.manifest!
 
@@ -41,6 +40,8 @@ export function createComponentWrapper(
 
         return () => {
           const isEmptyProps = Object.keys(attrs).length === 0
+          const strategy = props.__visle_strategy__
+          const options = props.__visle_options__
 
           return h(
             'vue-island',
@@ -48,6 +49,8 @@ export function createComponentWrapper(
               entry: clientImportId,
               'serialized-props': isEmptyProps ? undefined : JSON.stringify(attrs),
               'imported-name': importedName === 'default' ? undefined : importedName,
+              strategy: strategy === 'load' ? undefined : strategy,
+              options: options ? JSON.stringify(options) : undefined,
             },
             [h(OriginalComponent, attrs, slots)],
           )

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -492,6 +492,7 @@ declare module 'visle' {
   import type { ComponentProps } from 'visle'
 
   interface VisleEntries {
+    'with-visible-island': ComponentProps<typeof import('./pages/with-visible-island.vue')['default']>
     'with-svg-img': ComponentProps<typeof import('./pages/with-svg-img.vue')['default']>
     'with-slot': ComponentProps<typeof import('./pages/with-slot.vue')['default']>
     'with-shared-css': ComponentProps<typeof import('./pages/with-shared-css.vue')['default']>

--- a/test/__snapshots__/hydration.test.ts.snap
+++ b/test/__snapshots__/hydration.test.ts.snap
@@ -45,6 +45,23 @@ exports[`Client-side Hydration > 'Island with props' 1`] = `
 </div>
 `;
 
+exports[`Client-side Hydration > 'Island with visible strategy' 1`] = `
+<div>
+  <div style="height:2000px;">
+    Spacer
+  </div>
+  <vue-island
+    entry="/assets/Counter-[hash].js"
+    serialized-props="{&quot;count&quot;:10}"
+    strategy="visible"
+  >
+    <button>
+      Count: 10
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Client-side Hydration > 'Multiple islands on the same page' 1`] = `
 <div>
   <vue-island entry="/assets/CounterA-[hash].js">

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -552,6 +552,7 @@ exports[`Production Build SSR > Build output files 2`] = `
     "pages/with-svg-img.vue": [
       "assets/with-svg-img-[hash].css",
     ],
+    "pages/with-visible-island.vue": [],
   },
   "entryDir": "pages",
   "islandsBootstrap": "assets/custom-element-[hash].js",
@@ -583,6 +584,7 @@ declare module 'visle' {
   import type { ComponentProps } from 'visle'
 
   interface VisleEntries {
+    'with-visible-island': ComponentProps<typeof import('./pages/with-visible-island.vue')['default']>
     'with-svg-img': ComponentProps<typeof import('./pages/with-svg-img.vue')['default']>
     'with-slot': ComponentProps<typeof import('./pages/with-slot.vue')['default']>
     'with-shared-css': ComponentProps<typeof import('./pages/with-shared-css.vue')['default']>
@@ -617,7 +619,7 @@ export {}
 exports[`Production Build SSR with manual chunks > dynamic import shared CSS page includes the merged CSS 1`] = `
 <link
   rel="stylesheet"
-  href="/assets/with-svg-img-[hash].css"
+  href="/assets/with-visible-island-[hash].css"
 >
 <script
   type="module"
@@ -644,7 +646,7 @@ exports[`Production Build SSR with manual chunks > dynamic import shared CSS pag
 exports[`Production Build SSR with manual chunks > shared CSS page includes the merged CSS 1`] = `
 <link
   rel="stylesheet"
-  href="/assets/with-svg-img-[hash].css"
+  href="/assets/with-visible-island-[hash].css"
 >
 <script
   type="module"

--- a/test/fixtures/pages/with-visible-island.vue
+++ b/test/fixtures/pages/with-visible-island.vue
@@ -1,0 +1,10 @@
+<script setup>
+import Counter from '../components/Counter.vue'
+</script>
+
+<template>
+  <div>
+    <div style="height: 2000px">Spacer</div>
+    <Counter v-client:visible :count="10" />
+  </div>
+</template>

--- a/test/hydration.test.ts
+++ b/test/hydration.test.ts
@@ -17,6 +17,7 @@ const hydrationCases: { name: string; component: string; props?: Record<string, 
   { name: 'Island with named import', component: 'with-named-import' },
   { name: 'Island with barrel import', component: 'with-barrel-import' },
   { name: 'SVG image asset', component: 'with-svg-img' },
+  { name: 'Island with visible strategy', component: 'with-visible-island' },
 ]
 
 /**
@@ -85,10 +86,10 @@ describe('Client-side Hydration', () => {
   })
 
   /**
-   * Opens a page, waits for island hydration to complete,
+   * Opens a page, waits for the custom element to be defined,
    * and collects any page errors.
    */
-  async function openAndHydrate(
+  async function openPage(
     component: string,
   ): Promise<{ page: Page; errors: string[]; warnings: string[] }> {
     const page = await browser.newPage()
@@ -115,13 +116,31 @@ describe('Client-side Hydration', () => {
   }
 
   test.for(hydrationCases)('$name', async ({ component }) => {
-    const { page, errors, warnings } = await openAndHydrate(component)
+    const { page, errors, warnings } = await openPage(component)
 
     const html = await page.innerHTML('body')
     expect(normalizeHashes(html)).toMatchSnapshot()
     expect(warnings).toEqual([])
     expect(errors).toEqual([])
 
+    await page.close()
+  })
+
+  test('visible strategy defers hydration until scrolled into view', async () => {
+    const { page, warnings, errors } = await openPage('with-visible-island')
+
+    // Island should not be hydrated yet (it's below the viewport)
+    const isHydratedBefore = await page.evaluate(
+      () => '_vnode' in document.querySelector('vue-island')!,
+    )
+    expect(isHydratedBefore).toBe(false)
+
+    // Scroll to the bottom so the island enters the viewport
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForFunction(() => '_vnode' in document.querySelector('vue-island')!)
+
+    expect(warnings).toEqual([])
+    expect(errors).toEqual([])
     await page.close()
   })
 })


### PR DESCRIPTION
Supersedes #76

## Summary

- Adds `v-client:visible` hydration strategy that defers island hydration until the component enters the viewport using `IntersectionObserver`
- Supports optional `rootMargin` via directive expression: `v-client:visible="{ rootMargin: '200px' }"`
- Replaces `__visle_client__` prop with `__visle_strategy__` to distinguish between `load` and `visible` strategies

Closes #72

## Test plan

- [x] Unit tests for `findVClientElements` with `v-client:visible`
- [x] Unit tests for `VueIsland` visible strategy (deferred hydration, intersection trigger, disconnect cleanup, rootMargin)
- [x] E2E test confirming island is not hydrated until scrolled into view
- [x] All existing tests pass
- [x] Lint and build pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v-client:visible support to defer island hydration until the component scrolls into view, improving initial load performance.
  * Optional visibility options (e.g., rootMargin) can be provided to fine-tune when visibility triggers hydration.

* **Tests**
  * Added end-to-end and unit tests covering visibility-based lazy hydration, observer behavior, option propagation, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->