### PR TITLE
test: suppress Vite logs and fix dev loader leak

### DIFF
--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, test, expect, beforeEach } from 'vitest'
+import { afterEach, describe, test, expect, beforeEach } from 'vitest'
 
 import { visle } from '../build/index.ts'
 import { createDevLoader } from './dev.ts'
@@ -145,25 +145,32 @@ describe('createRender', () => {
   })
 
   describe('isDev = true', () => {
+    let loader: ReturnType<typeof createDevLoader> | undefined
+
+    afterEach(async () => {
+      await loader?.close()
+      loader = undefined
+    })
+
     test('renders vue component from component directory', async () => {
       const render = createRender({
         serverOutDir: path.join(root, 'dist/server'),
       })
 
-      render.setLoader(
-        createDevLoader({
-          root,
-          plugins: [visle()],
-          resolve: {
-            alias: {
-              'visle/internal': path.resolve(
-                path.dirname(fileURLToPath(import.meta.url)),
-                'internal.ts',
-              ),
-            },
+      loader = createDevLoader({
+        root,
+        plugins: [visle()],
+        resolve: {
+          alias: {
+            'visle/internal': path.resolve(
+              path.dirname(fileURLToPath(import.meta.url)),
+              'internal.ts',
+            ),
           },
-        }),
-      )
+        },
+      })
+
+      render.setLoader(loader)
 
       await saveCodes(root, {
         'pages/Comp.vue': `

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     snapshotSerializers: ['./test/html-serializer.ts'],
+    silent: 'passed-only',
   },
 })


### PR DESCRIPTION
## Summary
- Add `silent: 'passed-only'` to vitest config to suppress captured stdout/stderr (e.g. `[vite] connected.` messages) for passing tests
- Close the dev loader in `render.test.ts` `afterEach` to prevent resource leak

## Test plan
- [x] `pnpm test --run` passes with clean output (no `[vite] connected.` noise)