### PR TITLE
fix(ci): fix release workflow publish errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - run: pnpm install
+
       - name: Publish to JSR
         run: npx jsr publish
 

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "server side rendering",
     "template engine"
   ],
+  "license": "MIT",
+  "author": "Katashin",
   "repository": {
     "type": "git",
     "url": "https://github.com/ktsn/visle"
   },
-  "license": "MIT",
-  "author": "Katashin",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "server side rendering",
     "template engine"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ktsn/visle"
+  },
   "license": "MIT",
   "author": "Katashin",
   "files": [


### PR DESCRIPTION
## Summary
- Add `repository.url` to `package.json` — required by npm's `--provenance` flag to verify the publishing source matches the GitHub repository
- Add pnpm/node setup and `pnpm install` steps to the `publish-jsr` job so dependencies are available when JSR/Deno resolves imports

## Test plan
- [ ] Trigger a release and verify both `publish-npm` and `publish-jsr` jobs pass