### PR TITLE
fix(ci): fix JSR publish errors and add publish dry-run check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: denoland/setup-deno@v2
+      - uses: pnpm/action-setup@v4
 
-      - name: Install dependencies
-        run: deno install
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - run: pnpm install
 
       - name: Publish dry run
-        run: deno publish --dry-run
+        run: npx jsr publish --dry-run
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
 
       - uses: denoland/setup-deno@v2
 
+      - name: Install dependencies
+        run: deno install
+
       - name: Publish dry run
         run: deno publish --dry-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,16 @@ jobs:
       - name: Build
         run: pnpm build
 
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: denoland/setup-deno@v2
+
+      - name: Publish dry run
+        run: deno publish --dry-run
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/jsr.json
+++ b/jsr.json
@@ -2,6 +2,9 @@
   "name": "@ktsn/visle",
   "version": "0.3.0",
   "license": "MIT",
+  "publish": {
+    "exclude": ["test/"]
+  },
   "exports": {
     ".": "./src/server/index.ts",
     "./internal": "./src/server/internal.ts",

--- a/src/server/component-wrapper.ts
+++ b/src/server/component-wrapper.ts
@@ -8,7 +8,7 @@ export function createComponentWrapper(
   normalizedRelativePath: string,
   importedName: string,
   OriginalComponent: Component,
-) {
+): Component {
   return defineComponent({
     inheritAttrs: false,
 


### PR DESCRIPTION
## Summary

- Exclude `test/` directory from JSR publish to fix invalid non-ASCII path error (`non-ascii-テスト.vue`)
- Add explicit return type to `createComponentWrapper` to fix JSR slow types error
- Add `publish-dry-run` CI job that runs `deno publish --dry-run` to catch JSR publish errors before release

## Test plan

- [ ] Verify `publish-dry-run` CI job passes
- [ ] Verify existing CI jobs still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established GitHub Actions automation that validates package publishing readiness through dry-run checks integrated into the CI pipeline alongside other validation jobs
  * Updated package manifest configuration to ensure test files are excluded from distributed packages
  * Improved function type signatures with explicit return type annotations for better code clarity and IDE support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->