### PR TITLE
feat: add `v-client:idle` directive

### DIFF
--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -372,4 +372,11 @@ describe('findVClientElements', () => {
     expect(results).toHaveLength(1)
     expect(results[0]!.tag).toBe('Counter')
   })
+
+  test('finds element with v-client:idle', () => {
+    const children = parseTemplate('<Counter v-client:idle />')
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0]!.tag).toBe('Counter')
+  })
 })

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -135,7 +135,9 @@ export function findVClientElements(children: TemplateChildNode[]): ElementNode[
         prop.type === NodeTypes.DIRECTIVE &&
         prop.name === 'client' &&
         prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
-        (prop.arg.content === 'load' || prop.arg.content === 'visible'),
+        (prop.arg.content === 'load' ||
+          prop.arg.content === 'visible' ||
+          prop.arg.content === 'idle'),
     )
 
     if (hasVClient) {

--- a/src/client/custom-element.test.ts
+++ b/src/client/custom-element.test.ts
@@ -223,15 +223,6 @@ describe('VueIsland custom element', () => {
       vi.stubGlobal('cancelIdleCallback', mockCancelIdleCallback)
     })
 
-    test('does not hydrate immediately when strategy is idle', async () => {
-      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
-      document.body.appendChild(el)
-      await flushMicrotasks()
-
-      expect(createSSRApp).not.toHaveBeenCalled()
-      expect(mockRequestIdleCallback).toHaveBeenCalled()
-    })
-
     test('hydrates when idle callback fires', async () => {
       const el = createIsland({ entry: './test-entry', strategy: 'idle' })
       document.body.appendChild(el)

--- a/src/client/custom-element.test.ts
+++ b/src/client/custom-element.test.ts
@@ -208,6 +208,107 @@ describe('VueIsland custom element', () => {
     })
   })
 
+  describe('idle strategy', () => {
+    let mockRequestIdleCallback: ReturnType<typeof vi.fn>
+    let mockCancelIdleCallback: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockRequestIdleCallback = vi.fn((_cb: IdleRequestCallback) => {
+        // Store callback but don't call it immediately
+        return 42
+      })
+      mockCancelIdleCallback = vi.fn()
+
+      vi.stubGlobal('requestIdleCallback', mockRequestIdleCallback)
+      vi.stubGlobal('cancelIdleCallback', mockCancelIdleCallback)
+    })
+
+    test('does not hydrate immediately when strategy is idle', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+      expect(mockRequestIdleCallback).toHaveBeenCalled()
+    })
+
+    test('hydrates when idle callback fires', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+
+      // Fire the idle callback
+      const idleCallback = mockRequestIdleCallback.mock.calls[0]![0] as () => void
+      idleCallback()
+      await flushMicrotasks()
+
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('cleans up on disconnect before idle fires', async () => {
+      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      document.body.removeChild(el)
+
+      expect(mockCancelIdleCallback).toHaveBeenCalledWith(42)
+    })
+
+    test('passes timeout option from options attribute', async () => {
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'idle',
+        options: '{"timeout":2000}',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(mockRequestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 2000 })
+    })
+
+    test('falls back to load event + setTimeout when requestIdleCallback is unavailable', async () => {
+      vi.stubGlobal('requestIdleCallback', undefined)
+
+      // Simulate a loading document so the fallback waits for the load event
+      Object.defineProperty(document, 'readyState', {
+        value: 'loading',
+        writable: true,
+        configurable: true,
+      })
+
+      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+
+      // Restore readyState and simulate load event
+      Object.defineProperty(document, 'readyState', {
+        value: 'complete',
+        writable: true,
+        configurable: true,
+      })
+      window.dispatchEvent(new Event('load'))
+      await flushMicrotasks()
+
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('falls back to setTimeout immediately when requestIdleCallback is unavailable and document is already complete', async () => {
+      vi.stubGlobal('requestIdleCallback', undefined)
+
+      // document.readyState is already 'complete' in happy-dom by default
+      const el = createIsland({ entry: './test-entry', strategy: 'idle' })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+  })
+
   describe('disconnectedCallback', () => {
     test('unmounts the app on disconnect', async () => {
       const el = createIsland({ entry: './test-entry' })

--- a/src/client/strategy/idle.ts
+++ b/src/client/strategy/idle.ts
@@ -1,0 +1,37 @@
+import { IslandStrategy } from '../custom-element.js'
+
+export const idle: IslandStrategy = {
+  schedule: (wrapper, onReady) => {
+    if (typeof requestIdleCallback === 'function') {
+      const timeout = getTimeout(wrapper)
+      const id = requestIdleCallback(onReady, timeout !== undefined ? { timeout } : undefined)
+      return () => {
+        cancelIdleCallback(id)
+      }
+    }
+
+    // Fallback for browsers without requestIdleCallback.
+    // Wait for the load event, then defer with setTimeout.
+    if (document.readyState === 'complete') {
+      const id = setTimeout(onReady, 0)
+      return () => {
+        clearTimeout(id)
+      }
+    }
+
+    const onLoad = () => {
+      setTimeout(onReady, 0)
+    }
+
+    window.addEventListener('load', onLoad, { once: true })
+
+    return () => {
+      window.removeEventListener('load', onLoad)
+    }
+  },
+}
+
+function getTimeout(wrapper: HTMLElement): number | undefined {
+  const options = JSON.parse(wrapper.getAttribute('options') ?? '{}')
+  return typeof options?.timeout === 'number' ? options.timeout : undefined
+}

--- a/src/client/strategy/index.ts
+++ b/src/client/strategy/index.ts
@@ -1,8 +1,10 @@
 import { IslandStrategy } from '../custom-element.js'
+import { idle } from './idle.js'
 import { load } from './load.js'
 import { visible } from './visible.js'
 
 export const strategies: Record<string, IslandStrategy> = {
   load,
   visible,
+  idle,
 }

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -506,6 +506,7 @@ declare module 'visle' {
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
     'with-island-props': ComponentProps<typeof import('./pages/with-island-props.vue')['default']>
     'with-island-alias': ComponentProps<typeof import('./pages/with-island-alias.vue')['default']>
+    'with-idle-island': ComponentProps<typeof import('./pages/with-idle-island.vue')['default']>
     'with-dynamic-shared-css': ComponentProps<typeof import('./pages/with-dynamic-shared-css.vue')['default']>
     'with-css': ComponentProps<typeof import('./pages/with-css.vue')['default']>
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>

--- a/test/__snapshots__/hydration.test.ts.snap
+++ b/test/__snapshots__/hydration.test.ts.snap
@@ -16,6 +16,20 @@ exports[`Client-side Hydration > 'Island with barrel import' 1`] = `
 </div>
 `;
 
+exports[`Client-side Hydration > 'Island with idle strategy' 1`] = `
+<div>
+  <vue-island
+    entry="/assets/Counter-[hash].js"
+    serialized-props="{&quot;count&quot;:5}"
+    strategy="idle"
+  >
+    <button>
+      Count: 5
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Client-side Hydration > 'Island with named import' 1`] = `
 <div>
   <h1>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -536,6 +536,7 @@ exports[`Production Build SSR > Build output files 2`] = `
       "assets/StyledCounter-[hash].css",
       "assets/with-dynamic-shared-css-[hash].css",
     ],
+    "pages/with-idle-island.vue": [],
     "pages/with-island-alias.vue": [],
     "pages/with-island-props.vue": [],
     "pages/with-island.vue": [],
@@ -600,6 +601,7 @@ declare module 'visle' {
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
     'with-island-props': ComponentProps<typeof import('./pages/with-island-props.vue')['default']>
     'with-island-alias': ComponentProps<typeof import('./pages/with-island-alias.vue')['default']>
+    'with-idle-island': ComponentProps<typeof import('./pages/with-idle-island.vue')['default']>
     'with-dynamic-shared-css': ComponentProps<typeof import('./pages/with-dynamic-shared-css.vue')['default']>
     'with-css': ComponentProps<typeof import('./pages/with-css.vue')['default']>
     'with-css-src': ComponentProps<typeof import('./pages/with-css-src.vue')['default']>

--- a/test/fixtures/pages/with-idle-island.vue
+++ b/test/fixtures/pages/with-idle-island.vue
@@ -1,0 +1,9 @@
+<script setup>
+import Counter from '../components/Counter.vue'
+</script>
+
+<template>
+  <div>
+    <Counter v-client:idle :count="5" />
+  </div>
+</template>

--- a/test/hydration.test.ts
+++ b/test/hydration.test.ts
@@ -18,6 +18,7 @@ const hydrationCases: { name: string; component: string; props?: Record<string, 
   { name: 'Island with barrel import', component: 'with-barrel-import' },
   { name: 'SVG image asset', component: 'with-svg-img' },
   { name: 'Island with visible strategy', component: 'with-visible-island' },
+  { name: 'Island with idle strategy', component: 'with-idle-island' },
 ]
 
 /**
@@ -138,6 +139,17 @@ describe('Client-side Hydration', () => {
 
     // Scroll to the bottom so the island enters the viewport
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForFunction(() => '_vnode' in document.querySelector('vue-island')!)
+
+    expect(warnings).toEqual([])
+    expect(errors).toEqual([])
+    await page.close()
+  })
+
+  test('idle strategy hydrates when browser is idle', async () => {
+    const { page, warnings, errors } = await openPage('with-idle-island')
+
+    // The idle callback should fire quickly since there's nothing blocking the main thread
     await page.waitForFunction(() => '_vnode' in document.querySelector('vue-island')!)
 
     expect(warnings).toEqual([])


### PR DESCRIPTION
## Summary

- Add `v-client:idle` directive that defers island hydration until the browser's main thread is free using `requestIdleCallback`
- Fall back to `load` event + `setTimeout` for browsers without `requestIdleCallback` (Safari < 17.4)
- Support optional `timeout` via the `options` attribute (e.g., `v-client:idle="{ timeout: 2000 }"`)

Closes #73

## Test plan

- [x] Unit test: `v-client:idle` recognized by `findVClientElements`
- [x] Unit tests: idle strategy scheduling, cleanup, timeout option, and fallback paths
- [x] Integration test: idle strategy hydrates in Playwright e2e suite
- [x] All existing tests pass (`vp test`)
- [x] No new lint/type errors (`vp check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the v-client:idle directive to hydrate Island components when the browser is idle, with fallbacks for environments without requestIdleCallback and a configurable timeout option.

* **Tests**
  * Added unit and end-to-end tests covering idle-strategy hydration timing, cleanup, fallback behavior, and a fixture demonstrating an idle island.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->