### PR TITLE
feat: add `v-client:media` directive

### DIFF
--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -372,4 +372,11 @@ describe('findVClientElements', () => {
     expect(results).toHaveLength(1)
     expect(results[0]!.tag).toBe('Counter')
   })
+
+  test('finds element with v-client:media', () => {
+    const children = parseTemplate(`<MobileMenu v-client:media="'(max-width: 768px)'" />`)
+    const results = findVClientElements(children)
+    expect(results).toHaveLength(1)
+    expect(results[0]!.tag).toBe('MobileMenu')
+  })
 })

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -135,7 +135,9 @@ export function findVClientElements(children: TemplateChildNode[]): ElementNode[
         prop.type === NodeTypes.DIRECTIVE &&
         prop.name === 'client' &&
         prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
-        (prop.arg.content === 'load' || prop.arg.content === 'visible'),
+        (prop.arg.content === 'load' ||
+          prop.arg.content === 'visible' ||
+          prop.arg.content === 'media'),
     )
 
     if (hasVClient) {

--- a/src/client/custom-element.test.ts
+++ b/src/client/custom-element.test.ts
@@ -208,6 +208,96 @@ describe('VueIsland custom element', () => {
     })
   })
 
+  describe('media strategy', () => {
+    let mockMatchMedia: ReturnType<typeof vi.fn>
+    let changeHandler: ((event: MediaQueryListEvent) => void) | null
+    let mockRemoveEventListener: ReturnType<typeof vi.fn>
+
+    function stubMatchMedia(matches: boolean) {
+      changeHandler = null
+      mockRemoveEventListener = vi.fn()
+
+      const mql = {
+        matches,
+        addEventListener: vi.fn((_event: string, handler: (event: MediaQueryListEvent) => void) => {
+          changeHandler = handler
+        }),
+        removeEventListener: mockRemoveEventListener,
+      }
+
+      mockMatchMedia = vi.fn(() => mql)
+      vi.stubGlobal('matchMedia', mockMatchMedia)
+      return mql
+    }
+
+    test('hydrates immediately when media query matches', async () => {
+      stubMatchMedia(true)
+
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'media',
+        options: '"(max-width: 768px)"',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(mockMatchMedia).toHaveBeenCalledWith('(max-width: 768px)')
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('defers and hydrates when media query starts matching', async () => {
+      stubMatchMedia(false)
+
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'media',
+        options: '"(max-width: 768px)"',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+
+      // Simulate media query change
+      changeHandler!({ matches: true } as MediaQueryListEvent)
+      await flushMicrotasks()
+
+      expect(mockRemoveEventListener).toHaveBeenCalledWith('change', changeHandler)
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+
+    test('cleans up listener on disconnect before match', async () => {
+      stubMatchMedia(false)
+
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'media',
+        options: '"(max-width: 768px)"',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      document.body.removeChild(el)
+
+      // Simulate late media query change
+      changeHandler!({ matches: true } as MediaQueryListEvent)
+      await flushMicrotasks()
+
+      expect(createSSRApp).not.toHaveBeenCalled()
+    })
+
+    test('hydrates immediately when options attribute is missing', async () => {
+      const el = createIsland({
+        entry: './test-entry',
+        strategy: 'media',
+      })
+      document.body.appendChild(el)
+      await flushMicrotasks()
+
+      expect(createSSRApp).toHaveBeenCalledWith({ name: 'TestComponent' }, {})
+    })
+  })
+
   describe('disconnectedCallback', () => {
     test('unmounts the app on disconnect', async () => {
       const el = createIsland({ entry: './test-entry' })

--- a/src/client/strategy/index.ts
+++ b/src/client/strategy/index.ts
@@ -1,8 +1,10 @@
 import { IslandStrategy } from '../custom-element.js'
 import { load } from './load.js'
+import { media } from './media.js'
 import { visible } from './visible.js'
 
 export const strategies: Record<string, IslandStrategy> = {
   load,
   visible,
+  media,
 }

--- a/src/client/strategy/media.ts
+++ b/src/client/strategy/media.ts
@@ -1,0 +1,41 @@
+import { IslandStrategy } from '../custom-element.js'
+
+export const media: IslandStrategy = {
+  schedule: (wrapper, onReady) => {
+    const query = getMediaQuery(wrapper)
+
+    if (!query) {
+      onReady()
+      return undefined
+    }
+
+    const mql = window.matchMedia(query)
+
+    if (mql.matches) {
+      onReady()
+      return undefined
+    }
+
+    const handler = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        mql.removeEventListener('change', handler)
+        onReady()
+      }
+    }
+
+    mql.addEventListener('change', handler)
+
+    return () => {
+      mql.removeEventListener('change', handler)
+    }
+  },
+}
+
+function getMediaQuery(wrapper: HTMLElement): string | undefined {
+  const options = wrapper.getAttribute('options')
+  if (!options) {
+    return undefined
+  }
+  const parsed = JSON.parse(options)
+  return typeof parsed === 'string' ? parsed : undefined
+}

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -503,6 +503,7 @@ declare module 'visle' {
     'with-named-import': ComponentProps<typeof import('./pages/with-named-import.vue')['default']>
     'with-multiple-islands': ComponentProps<typeof import('./pages/with-multiple-islands.vue')['default']>
     'with-mount-variation': ComponentProps<typeof import('./pages/with-mount-variation.vue')['default']>
+    'with-media-island': ComponentProps<typeof import('./pages/with-media-island.vue')['default']>
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
     'with-island-props': ComponentProps<typeof import('./pages/with-island-props.vue')['default']>
     'with-island-alias': ComponentProps<typeof import('./pages/with-island-alias.vue')['default']>

--- a/test/__snapshots__/hydration.test.ts.snap
+++ b/test/__snapshots__/hydration.test.ts.snap
@@ -16,6 +16,21 @@ exports[`Client-side Hydration > 'Island with barrel import' 1`] = `
 </div>
 `;
 
+exports[`Client-side Hydration > 'Island with media strategy' 1`] = `
+<div>
+  <vue-island
+    entry="/assets/Counter-[hash].js"
+    serialized-props="{&quot;count&quot;:5}"
+    strategy="media"
+    options="&quot;(max-width: 768px)&quot;"
+  >
+    <button>
+      Count: 5
+    </button>
+  </vue-island>
+</div>
+`;
+
 exports[`Client-side Hydration > 'Island with named import' 1`] = `
 <div>
   <h1>

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -539,6 +539,7 @@ exports[`Production Build SSR > Build output files 2`] = `
     "pages/with-island-alias.vue": [],
     "pages/with-island-props.vue": [],
     "pages/with-island.vue": [],
+    "pages/with-media-island.vue": [],
     "pages/with-mount-variation.vue": [],
     "pages/with-multiple-islands.vue": [],
     "pages/with-named-import.vue": [],
@@ -597,6 +598,7 @@ declare module 'visle' {
     'with-named-import': ComponentProps<typeof import('./pages/with-named-import.vue')['default']>
     'with-multiple-islands': ComponentProps<typeof import('./pages/with-multiple-islands.vue')['default']>
     'with-mount-variation': ComponentProps<typeof import('./pages/with-mount-variation.vue')['default']>
+    'with-media-island': ComponentProps<typeof import('./pages/with-media-island.vue')['default']>
     'with-island': ComponentProps<typeof import('./pages/with-island.vue')['default']>
     'with-island-props': ComponentProps<typeof import('./pages/with-island-props.vue')['default']>
     'with-island-alias': ComponentProps<typeof import('./pages/with-island-alias.vue')['default']>

--- a/test/fixtures/pages/with-media-island.vue
+++ b/test/fixtures/pages/with-media-island.vue
@@ -1,0 +1,9 @@
+<script setup>
+import Counter from '../components/Counter.vue'
+</script>
+
+<template>
+  <div>
+    <Counter v-client:media="'(max-width: 768px)'" :count="5" />
+  </div>
+</template>

--- a/test/hydration.test.ts
+++ b/test/hydration.test.ts
@@ -18,6 +18,7 @@ const hydrationCases: { name: string; component: string; props?: Record<string, 
   { name: 'Island with barrel import', component: 'with-barrel-import' },
   { name: 'SVG image asset', component: 'with-svg-img' },
   { name: 'Island with visible strategy', component: 'with-visible-island' },
+  { name: 'Island with media strategy', component: 'with-media-island' },
 ]
 
 /**
@@ -138,6 +139,25 @@ describe('Client-side Hydration', () => {
 
     // Scroll to the bottom so the island enters the viewport
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForFunction(() => '_vnode' in document.querySelector('vue-island')!)
+
+    expect(warnings).toEqual([])
+    expect(errors).toEqual([])
+    await page.close()
+  })
+
+  test('media strategy defers hydration until media query matches', async () => {
+    // Open page with a wide viewport (media query "(max-width: 768px)" won't match)
+    const { page, warnings, errors } = await openPage('with-media-island')
+
+    // Island should not be hydrated yet (viewport is wider than 768px)
+    const isHydratedBefore = await page.evaluate(
+      () => '_vnode' in document.querySelector('vue-island')!,
+    )
+    expect(isHydratedBefore).toBe(false)
+
+    // Resize viewport to a narrow width so the media query matches
+    await page.setViewportSize({ width: 500, height: 600 })
     await page.waitForFunction(() => '_vnode' in document.querySelector('vue-island')!)
 
     expect(warnings).toEqual([])


### PR DESCRIPTION
## Summary

Closes #74

- Add `v-client:media` directive that defers island hydration until a CSS media query matches (e.g., `<MobileMenu v-client:media="'(max-width: 768px)'" />`)
- Uses `window.matchMedia()` to check/listen for query match, hydrating immediately if already matched or on first `change` event
- Cleans up event listener on disconnect

## Test plan

- [x] Unit tests: `v-client:media` recognized by `findVClientElements()` in SFC analysis
- [x] Unit tests: media strategy hydrates immediately when query matches, defers when it doesn't, hydrates on change, cleans up on disconnect, falls back when options missing
- [x] E2E test: island defers hydration at wide viewport, hydrates after resize to narrow viewport
- [x] `vp test` — all 197 tests pass
- [x] `vp check` — no new lint/type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a media query–based component hydration strategy that defers initialization until viewport conditions match, with automatic listener cleanup.

* **Tests**
  * Expanded test coverage and fixtures for the media-based hydration behavior, including immediate hydrate, deferred hydrate after viewport change, cleanup on disconnect, and end-to-end hydration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->