### PR TITLE
refactor: avoid duplicated regexp for drive letter

### DIFF
--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -21,7 +21,7 @@ function hasDriveLetter(p: string): boolean {
  * Matches `/` or drive letter like `C:/`
  */
 function isAbsolute(p: string): boolean {
-  return p.startsWith('/') || /^[a-zA-Z]:\//.test(p)
+  return p.startsWith('/') || hasDriveLetter(p)
 }
 
 export function asAbs(value: string): AbsolutePath {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows path handling to treat drive-letter-prefixed paths as absolute, improving compatibility with paths formatted as drive letter with colon (e.g., "C:foo").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->