### PR TITLE
feat: allow to specify vite vue plugin options

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -1,11 +1,8 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import vue from '@vitejs/plugin-vue'
-import { createObjectProperty, createSimpleExpression, NodeTypes } from '@vue/compiler-core'
 import type { Plugin } from 'vite'
 
-import { generateComponentId } from '../core/component-id.js'
 import { type VisleConfig, defaultConfig, setVisleConfig } from '../core/config.js'
 import { manifestFileName } from '../core/manifest.js'
 import { asAbs, join, resolve } from '../core/path.js'
@@ -16,6 +13,7 @@ import { entryTypesPlugin } from './plugins/entry-types.js'
 import { manifestPlugin } from './plugins/manifest.js'
 import { serverTransformPlugin } from './plugins/server-transform.js'
 import { virtualFilePlugin } from './plugins/virtual-file.js'
+import { wrapVuePlugin } from './vue.js'
 
 export type { VisleConfig }
 
@@ -35,6 +33,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
   const virtualFile = virtualFilePlugin(resolvedConfig)
   const { plugin: manifest, getManifestData } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
+  const vuePlugin = wrapVuePlugin(resolvedConfig)
 
   const orchestrationPlugin: Plugin = {
     name: 'visle:orchestration',
@@ -145,44 +144,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     virtualFile,
     manifest,
     entryTypes,
-    vue({
-      features: {
-        componentIdGenerator: (filePath, source, isProduction) => {
-          return generateComponentId(filePath, source, isProduction ?? false)
-        },
-      },
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) => tag === 'vue-island',
-          directiveTransforms: {
-            // server-transform plugin searches v-client directive to detect
-            // island component. Strip v-client directive here to make sure to
-            // remove it in all environment.
-            client: (dir) => {
-              const props = [
-                createObjectProperty(
-                  createSimpleExpression('__visle_strategy__', true),
-                  createSimpleExpression(
-                    JSON.stringify(
-                      dir.arg?.type === NodeTypes.SIMPLE_EXPRESSION ? dir.arg.content : 'load',
-                    ),
-                    false,
-                  ),
-                ),
-              ]
-
-              if (dir.exp) {
-                props.push(
-                  createObjectProperty(createSimpleExpression('__visle_options__', true), dir.exp),
-                )
-              }
-
-              return { props }
-            },
-          },
-        },
-      },
-    }),
+    vuePlugin,
     devStyleSSRPlugin(),
   ]
 }

--- a/src/build/vue.test.ts
+++ b/src/build/vue.test.ts
@@ -9,7 +9,7 @@ import { defaultConfig, type ResolvedVisleConfig } from '../core/config.ts'
 import { wrapVuePlugin } from './vue.ts'
 
 const root = path.resolve(__dirname, '..', '..')
-const tempDir = path.resolve(root, 'test/__generated__/server')
+const tempDir = path.resolve(root, 'test/__generated__/server/vue-plugin')
 
 describe('wrapVuePlugin', () => {
   let server: ViteDevServer | undefined

--- a/src/build/vue.test.ts
+++ b/src/build/vue.test.ts
@@ -131,7 +131,7 @@ describe('wrapVuePlugin', () => {
 
     // whitespace: 'preserve' should keep whitespace as-is
     expect(code).toContain('  hello  ')
-    // comments: true should keep HTML comments in the output
+    // comments: false should remove HTML comments from the output
     expect(code).not.toContain('greeting')
   })
 

--- a/src/build/vue.test.ts
+++ b/src/build/vue.test.ts
@@ -110,6 +110,31 @@ describe('wrapVuePlugin', () => {
     expect(code).toContain('__visle_strategy__')
   })
 
+  test('additional compilerOptions', async () => {
+    await createTestServer({
+      ...defaultConfig,
+      vue: {
+        template: {
+          compilerOptions: {
+            whitespace: 'preserve',
+            comments: false,
+          },
+        },
+      },
+    })
+
+    const filePath = await writeTempVue(
+      'compiler-options',
+      `<template><div>  hello  <!-- greeting -->  world  </div></template>`,
+    )
+    const code = await transform(filePath)
+
+    // whitespace: 'preserve' should keep whitespace as-is
+    expect(code).toContain('  hello  ')
+    // comments: true should keep HTML comments in the output
+    expect(code).not.toContain('greeting')
+  })
+
   test('additional feature', async () => {
     await createTestServer({
       ...defaultConfig,

--- a/src/build/vue.test.ts
+++ b/src/build/vue.test.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { createObjectProperty, createSimpleExpression } from '@vue/compiler-core'
+import { createServer, type ViteDevServer } from 'vite'
+import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
+
+import { defaultConfig, type ResolvedVisleConfig } from '../core/config.ts'
+import { wrapVuePlugin } from './vue.ts'
+
+const root = path.resolve(__dirname, '..', '..')
+const tempDir = path.resolve(root, 'test/__generated__/server')
+
+describe('wrapVuePlugin', () => {
+  let server: ViteDevServer | undefined
+  const tempFiles: string[] = []
+
+  beforeEach(async () => {
+    await fs.mkdir(tempDir, { recursive: true })
+  })
+
+  async function createTestServer(config: ResolvedVisleConfig) {
+    server = await createServer({
+      configFile: false,
+      plugins: [wrapVuePlugin(config)],
+      appType: 'custom',
+      server: { middlewareMode: true },
+      optimizeDeps: { noDiscovery: true },
+      logLevel: 'silent',
+    })
+    return server
+  }
+
+  async function writeTempVue(name: string, content: string): Promise<string> {
+    const filePath = path.resolve(tempDir, `${name}.vue`)
+    await fs.writeFile(filePath, content)
+    tempFiles.push(filePath)
+    return filePath
+  }
+
+  async function transform(filePath: string): Promise<string> {
+    const result = await server!.environments.client.transformRequest(filePath.replace(root, ''))
+    expect(result).not.toBeNull()
+    return result!.code
+  }
+
+  afterEach(async () => {
+    await server?.close()
+    server = undefined
+    await Promise.all(tempFiles.map((f) => fs.unlink(f).catch(() => {})))
+    tempFiles.length = 0
+  })
+
+  test('additional custom element', async () => {
+    await createTestServer({
+      ...defaultConfig,
+      vue: {
+        template: {
+          compilerOptions: {
+            isCustomElement: (tag) => tag === 'my-element',
+          },
+        },
+      },
+    })
+
+    const filePath = await writeTempVue(
+      'custom-element',
+      `<template><div><my-element /><vue-island /></div></template>`,
+    )
+    const code = await transform(filePath)
+
+    // my-element should be treated as native (no resolveComponent call)
+    expect(code).not.toContain('resolveComponent("my-element")')
+    // vue-island should also be treated as native (Visle built-in)
+    expect(code).not.toContain('resolveComponent("vue-island")')
+  })
+
+  test('additional directiveTransform', async () => {
+    await createTestServer({
+      ...defaultConfig,
+      vue: {
+        template: {
+          compilerOptions: {
+            directiveTransforms: {
+              highlight: () => {
+                return {
+                  props: [
+                    createObjectProperty(
+                      createSimpleExpression('__test_highlight__', true),
+                      createSimpleExpression('true', true),
+                    ),
+                  ],
+                }
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const filePath = await writeTempVue(
+      'directive',
+      `<template><div v-highlight v-client /></template>`,
+    )
+    const code = await transform(filePath)
+
+    // Custom directive transform should have been called
+    expect(code).toContain('__test_highlight__')
+    // Visle's client directive transform should still produce its output
+    expect(code).toContain('__visle_strategy__')
+  })
+
+  test('additional feature', async () => {
+    await createTestServer({
+      ...defaultConfig,
+      vue: {
+        features: {
+          customElement: /\.vue$/,
+        },
+      },
+    })
+
+    const filePath = await writeTempVue(
+      'feature-ce',
+      `<template>
+  <div>Test</div>
+</template>
+<style>
+div { color: red; }
+</style>
+`,
+    )
+    const code = await transform(filePath)
+
+    // With customElement enabled, styles are attached as an inline array
+    // on the component for shadow DOM injection instead of injected globally
+    expect(code).toContain("'styles'")
+    expect(code).toContain('_style_0')
+  })
+})

--- a/src/build/vue.ts
+++ b/src/build/vue.ts
@@ -1,0 +1,63 @@
+import vuePlugin from '@vitejs/plugin-vue'
+import { createObjectProperty, createSimpleExpression, NodeTypes } from '@vue/compiler-core'
+
+import { generateComponentId } from '../core/component-id.js'
+import { ResolvedVisleConfig } from '../core/config.js'
+
+/**
+ * Wrap @vitejs/plugin-vue to inject Visle specific options.
+ * Users can specify their own options in the Visle config, which will be merged with the defaults.
+ */
+export function wrapVuePlugin(config: ResolvedVisleConfig) {
+  return vuePlugin({
+    ...config.vue,
+
+    features: {
+      ...config.vue?.features,
+      componentIdGenerator: (filePath, source, isProduction) => {
+        return generateComponentId(filePath, source, isProduction ?? false)
+      },
+    },
+
+    template: {
+      ...config.vue?.template,
+
+      compilerOptions: {
+        isCustomElement: (tag) => {
+          return (
+            tag === 'vue-island' || config.vue?.template?.compilerOptions?.isCustomElement?.(tag)
+          )
+        },
+
+        directiveTransforms: {
+          ...config.vue?.template?.compilerOptions?.directiveTransforms,
+
+          // server-transform plugin searches v-client directive to detect
+          // island component. Strip v-client directive here to make sure to
+          // remove it in all environment.
+          client: (dir) => {
+            const props = [
+              createObjectProperty(
+                createSimpleExpression('__visle_strategy__', true),
+                createSimpleExpression(
+                  JSON.stringify(
+                    dir.arg?.type === NodeTypes.SIMPLE_EXPRESSION ? dir.arg.content : 'load',
+                  ),
+                  false,
+                ),
+              ),
+            ]
+
+            if (dir.exp) {
+              props.push(
+                createObjectProperty(createSimpleExpression('__visle_options__', true), dir.exp),
+              )
+            }
+
+            return { props }
+          },
+        },
+      },
+    },
+  })
+}

--- a/src/build/vue.ts
+++ b/src/build/vue.ts
@@ -2,7 +2,7 @@ import vuePlugin from '@vitejs/plugin-vue'
 import { createObjectProperty, createSimpleExpression, NodeTypes } from '@vue/compiler-core'
 
 import { generateComponentId } from '../core/component-id.js'
-import { ResolvedVisleConfig } from '../core/config.js'
+import type { ResolvedVisleConfig } from '../core/config.js'
 
 /**
  * Wrap @vitejs/plugin-vue to inject Visle specific options.
@@ -23,6 +23,8 @@ export function wrapVuePlugin(config: ResolvedVisleConfig) {
       ...config.vue?.template,
 
       compilerOptions: {
+        ...config.vue?.template?.compilerOptions,
+
         isCustomElement: (tag) => {
           return (
             tag === 'vue-island' || config.vue?.template?.compilerOptions?.isCustomElement?.(tag)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,3 +1,5 @@
+import type { Options } from '@vitejs/plugin-vue'
+
 /**
  * Configuration for Visle plugin
  */
@@ -6,6 +8,9 @@ export interface VisleConfig {
   serverOutDir?: string
   clientOutDir?: string
   dts?: string | null
+
+  /** @vitejs/plugin-vue options */
+  vue?: Options
 }
 
 /**
@@ -18,6 +23,7 @@ export const defaultConfig: ResolvedVisleConfig = {
   clientOutDir: 'dist/client',
   serverOutDir: 'dist/server',
   dts: 'visle-generated.d.ts',
+  vue: {},
 }
 
 const visleConfigKey = '__visle'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Vue compiler options, including custom elements and directive transforms, can now be configured through Visle config.

* **Refactor**
  * Reorganized Vue Vite plugin setup from inline configuration to a dedicated wrapper module for better modularity.

* **Tests**
  * Added comprehensive test suite covering Vue compiler options and custom directive transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->