### PR TITLE
fix: generate correct import path in d.ts when output to non-root directory

### DIFF
--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -6,13 +6,13 @@ import { generateEntryTypesCode } from './generate.ts'
 describe('generateEntryTypesCode', () => {
   test('generates module augmentation with component entries', () => {
     const entryDir = asAbs('/project/pages')
-    const root = asAbs('/project')
+    const dtsDir = asAbs('/project')
     const componentIds = [
       asAbs('/project/pages/static.vue'),
       asAbs('/project/pages/with-props.vue'),
     ]
 
-    const result = generateEntryTypesCode(entryDir, root, componentIds)
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
 
     expect(result).toContain(
       "'static': ComponentProps<typeof import('./pages/static.vue')['default']>",
@@ -24,10 +24,10 @@ describe('generateEntryTypesCode', () => {
 
   test('handles nested components', () => {
     const entryDir = asAbs('/project/pages')
-    const root = asAbs('/project')
+    const dtsDir = asAbs('/project')
     const componentIds = [asAbs('/project/pages/nested/index.vue')]
 
-    const result = generateEntryTypesCode(entryDir, root, componentIds)
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
 
     expect(result).toContain(
       "'nested/index': ComponentProps<typeof import('./pages/nested/index.vue')['default']>",

--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -42,6 +42,18 @@ describe('generateEntryTypesCode', () => {
     expect(result).toContain('interface VisleEntries {\n\n  }')
   })
 
+  test('generates import paths relative to dts directory', () => {
+    const entryDir = asAbs('/project/pages')
+    const dtsDir = asAbs('/project/types')
+    const componentIds = [asAbs('/project/pages/static.vue')]
+
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
+
+    expect(result).toContain(
+      "'static': ComponentProps<typeof import('../pages/static.vue')['default']>",
+    )
+  })
+
   test('include empty export', () => {
     const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [])
 

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -49,16 +49,26 @@ export function generateComponentWrapperCode(
   return lines.join('\n') + '\n'
 }
 
+/**
+ * Generate d.ts content to annotate Visle's `render` function
+ * with the entry components and their props types.
+ *
+ * @param entryDir Entry components directory (VisleConfig#entryDir)
+ * @param dtsDir Output directory of the d.ts file (dirname of VisleConfig#dts)
+ * @param componentIds All entry component file paths
+ * @returns Generated d.ts content
+ */
 export function generateEntryTypesCode(
   entryDir: AbsolutePath,
-  root: AbsolutePath,
+  dtsDir: AbsolutePath,
   componentIds: AbsolutePath[],
 ): string {
   const entries = componentIds
     .map((id) => {
       const key = relative(entryDir, id).replace(/\.vue$/, '')
-      const importPath = relative(root, id)
-      return `    '${key}': ComponentProps<typeof import('./${importPath}')['default']>`
+      const importPath = relative(dtsDir, id)
+      const importSpecifier = importPath.startsWith('.') ? importPath : `./${importPath}`
+      return `    '${key}': ComponentProps<typeof import('${importSpecifier}')['default']>`
     })
     .join('\n')
 

--- a/src/build/plugins/entry-types.test.ts
+++ b/src/build/plugins/entry-types.test.ts
@@ -62,7 +62,6 @@ describe('entryTypesPlugin', () => {
     await hook(createServer(watcher))
 
     expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages')
-    expect(fs.mkdir).toHaveBeenCalledWith('/project', { recursive: true })
     expect(fs.writeFile).toHaveBeenCalledWith(
       '/project/visle-generated.d.ts',
       expect.stringMatching('Index'),
@@ -228,6 +227,7 @@ describe('entryTypesPlugin', () => {
 
     await generate()
 
+    expect(fs.mkdir).toHaveBeenCalledWith('/project/types', { recursive: true })
     expect(fs.writeFile).toHaveBeenCalledWith(
       '/project/types/visle.d.ts',
       expect.stringMatching('Index'),

--- a/src/build/plugins/entry-types.test.ts
+++ b/src/build/plugins/entry-types.test.ts
@@ -13,6 +13,7 @@ import { entryTypesPlugin } from './entry-types.ts'
 vi.mock('node:fs/promises', () => ({
   default: {
     writeFile: vi.fn(() => Promise.resolve()),
+    mkdir: vi.fn(() => Promise.resolve()),
   },
 }))
 
@@ -61,6 +62,7 @@ describe('entryTypesPlugin', () => {
     await hook(createServer(watcher))
 
     expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages')
+    expect(fs.mkdir).toHaveBeenCalledWith('/project', { recursive: true })
     expect(fs.writeFile).toHaveBeenCalledWith(
       '/project/visle-generated.d.ts',
       expect.stringMatching('Index'),

--- a/src/build/plugins/entry-types.ts
+++ b/src/build/plugins/entry-types.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs/promises'
-import path from 'node:path'
 
 import type { Plugin } from 'vite'
 
 import type { ResolvedVisleConfig } from '../../shared/config.js'
-import { type AbsolutePath, asAbs, resolve } from '../../shared/path.js'
+import { type AbsolutePath, asAbs, dirname, resolve } from '../../shared/path.js'
 import { generateEntryTypesCode } from '../generate.js'
 import { resolveServerComponentIds } from '../paths.js'
 
@@ -31,14 +30,15 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
 
   async function generateAndWrite(): Promise<void> {
     const componentIds = resolveServerComponentIds(entryRoot)
-    const content = generateEntryTypesCode(entryRoot, root, componentIds)
+    const dtsDir = dirname(dtsPath)
+    const content = generateEntryTypesCode(entryRoot, dtsDir, componentIds)
 
     if (content === lastContent) {
       return
     }
 
     lastContent = content
-    await fs.mkdir(path.dirname(dtsPath), { recursive: true })
+    await fs.mkdir(dtsDir, { recursive: true })
     await fs.writeFile(dtsPath, content)
   }
 

--- a/src/build/plugins/entry-types.ts
+++ b/src/build/plugins/entry-types.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import path from 'node:path'
 
 import type { Plugin } from 'vite'
 
@@ -37,6 +38,7 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
     }
 
     lastContent = content
+    await fs.mkdir(path.dirname(dtsPath), { recursive: true })
     await fs.writeFile(dtsPath, content)
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure parent directories for generated type files are created before writing.
  * Fix import path computation so component type imports are resolved relative to the configured types directory.

* **Tests**
  * Expanded tests to cover import path generation relative to the types directory and verify directory creation prior to writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->