### PR TITLE
chore: group vite-plus related packages in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*"],
+      "groupName": "vite-plus"
     }
   ]
 }


### PR DESCRIPTION
Group vite-plus, @voidzero-dev/vite-plus-core, and @voidzero-dev/vite-plus-test into a single PR when updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->