### PR TITLE
feat: add generate option

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -10,6 +10,7 @@ import { serverVirtualEntryId } from './generate.js'
 import { islandsBootstrapPath, resolveServerComponentIds } from './paths.js'
 import { devStyleSSRPlugin } from './plugins/dev-style-ssr.js'
 import { entryTypesPlugin } from './plugins/entry-types.js'
+import { generateHtmlPlugin, generateVirtualEntryId } from './plugins/generate-html.js'
 import { manifestPlugin } from './plugins/manifest.js'
 import { serverTransformPlugin } from './plugins/server-transform.js'
 import { virtualFilePlugin } from './plugins/virtual-file.js'
@@ -33,6 +34,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
   const virtualFile = virtualFilePlugin(resolvedConfig)
   const { plugin: manifest, getManifestData } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
+  const generateHtml = generateHtmlPlugin(resolvedConfig)
   const vuePlugin = wrapVuePlugin(resolvedConfig)
 
   const orchestrationPlugin: Plugin = {
@@ -45,6 +47,15 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
       return {
         environments: {
+          server: {
+            consumer: 'server',
+            build: {
+              outDir: resolvedConfig.serverOutDir,
+              rollupOptions: {
+                input: [serverVirtualEntryId],
+              },
+            },
+          },
           style: {
             consumer: 'client',
             build: {
@@ -68,15 +79,20 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               },
             },
           },
-          server: {
-            consumer: 'server',
-            build: {
-              outDir: resolvedConfig.serverOutDir,
-              rollupOptions: {
-                input: [serverVirtualEntryId],
-              },
-            },
-          },
+          ...(resolvedConfig.generate
+            ? {
+                generate: {
+                  consumer: 'client',
+                  build: {
+                    outDir: resolvedConfig.clientOutDir,
+                    emptyOutDir: false,
+                    rollupOptions: {
+                      input: [generateVirtualEntryId],
+                    },
+                  },
+                },
+              }
+            : {}),
         },
 
         builder: {
@@ -103,6 +119,11 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               ),
               generateEntryTypes(),
             ])
+
+            // Generate static HTML files for all entries (when enabled)
+            if (resolvedConfig.generate) {
+              await builder.build(builder.environments.generate!)
+            }
           },
         },
       }
@@ -144,6 +165,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     virtualFile,
     manifest,
     entryTypes,
+    generateHtml,
     vuePlugin,
     devStyleSSRPlugin(),
   ]

--- a/src/build/plugins/generate-html.test.ts
+++ b/src/build/plugins/generate-html.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
+
+import { prodBuild } from '../../../test/utils.ts'
+import { entryKeyToHtmlPath } from './generate-html.ts'
+
+const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generated__/server')
+
+let root: string
+
+beforeEach(async () => {
+  await fs.mkdir(generatedDir, { recursive: true })
+  root = await fs.mkdtemp(path.join(generatedDir, 'generate-html-'))
+  await fs.mkdir(path.join(root, 'pages'), { recursive: true })
+})
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+})
+
+describe('entryKeyToHtmlPath', () => {
+  test('index maps to index.html', () => {
+    expect(entryKeyToHtmlPath('index')).toBe('index.html')
+  })
+
+  test('non-index maps to name/index.html', () => {
+    expect(entryKeyToHtmlPath('profile')).toBe('profile/index.html')
+  })
+
+  test('nested index maps to nested/index.html', () => {
+    expect(entryKeyToHtmlPath('nested/index')).toBe('nested/index.html')
+  })
+
+  test('nested non-index maps to nested/name/index.html', () => {
+    expect(entryKeyToHtmlPath('nested/detail')).toBe('nested/detail/index.html')
+  })
+})
+
+describe('generateHtmlPlugin', () => {
+  test('outputs rendered HTML for each .vue entry', async () => {
+    await fs.writeFile(path.join(root, 'pages/index.vue'), '<template><h1>Home</h1></template>')
+    await fs.writeFile(path.join(root, 'pages/about.vue'), '<template><p>About</p></template>')
+
+    await prodBuild(root, {}, { generate: true })
+
+    const indexHtml = await fs.readFile(path.join(root, 'dist/client/index.html'), 'utf-8')
+    expect(indexHtml).toContain('<h1>Home</h1>')
+
+    const aboutHtml = await fs.readFile(path.join(root, 'dist/client/about/index.html'), 'utf-8')
+    expect(aboutHtml).toContain('<p>About</p>')
+  })
+})

--- a/src/build/plugins/generate-html.test.ts
+++ b/src/build/plugins/generate-html.test.ts
@@ -51,4 +51,30 @@ describe('generateHtmlPlugin', () => {
     const aboutHtml = await fs.readFile(path.join(root, 'dist/client/about/index.html'), 'utf-8')
     expect(aboutHtml).toContain('<p>About</p>')
   })
+
+  test('errors when entry components have props defined', async () => {
+    await fs.writeFile(
+      path.join(root, 'pages/index.vue'),
+      '<script setup lang="ts">defineProps<{ message: string }>()</script><template><div>{{ message }}</div></template>',
+    )
+    await fs.writeFile(
+      path.join(root, 'pages/about.vue'),
+      '<script setup lang="ts">defineProps<{ title: string }>()</script><template><p>{{ title }}</p></template>',
+    )
+    await fs.writeFile(
+      path.join(root, 'pages/static.vue'),
+      '<template><div>No props</div></template>',
+    )
+
+    let message = ''
+    try {
+      await prodBuild(root, {}, { generate: true })
+    } catch (e) {
+      message = String(e)
+    }
+    expect(message).toMatch('The following entries cannot have props when using generate option:')
+    expect(message).toMatch('- about')
+    expect(message).toMatch('- index')
+    expect(message).not.toMatch('- static')
+  })
 })

--- a/src/build/plugins/generate-html.test.ts
+++ b/src/build/plugins/generate-html.test.ts
@@ -6,20 +6,6 @@ import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 import { prodBuild } from '../../../test/utils.ts'
 import { entryKeyToHtmlPath } from './generate-html.ts'
 
-const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generated__/server')
-
-let root: string
-
-beforeEach(async () => {
-  await fs.mkdir(generatedDir, { recursive: true })
-  root = await fs.mkdtemp(path.join(generatedDir, 'generate-html-'))
-  await fs.mkdir(path.join(root, 'pages'), { recursive: true })
-})
-
-afterEach(async () => {
-  await fs.rm(root, { recursive: true, force: true })
-})
-
 describe('entryKeyToHtmlPath', () => {
   test('index maps to index.html', () => {
     expect(entryKeyToHtmlPath('index')).toBe('index.html')
@@ -39,6 +25,20 @@ describe('entryKeyToHtmlPath', () => {
 })
 
 describe('generateHtmlPlugin', () => {
+  const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generated__/server')
+
+  let root: string
+
+  beforeEach(async () => {
+    await fs.mkdir(generatedDir, { recursive: true })
+    root = await fs.mkdtemp(path.join(generatedDir, 'generate-html-'))
+    await fs.mkdir(path.join(root, 'pages'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
   test('outputs rendered HTML for each .vue entry', async () => {
     await fs.writeFile(path.join(root, 'pages/index.vue'), '<template><h1>Home</h1></template>')
     await fs.writeFile(path.join(root, 'pages/about.vue'), '<template><p>About</p></template>')

--- a/src/build/plugins/generate-html.ts
+++ b/src/build/plugins/generate-html.ts
@@ -1,0 +1,65 @@
+import type { Plugin } from 'vite'
+
+import { createRender } from '../../server/render.js'
+import type { ResolvedVisleConfig } from '../../shared/config.js'
+import { asAbs, relative, resolve } from '../../shared/path.js'
+import { resolveServerComponentIds } from '../paths.js'
+
+export const generateVirtualEntryId = '\0@visle/generate-entry'
+
+export function entryKeyToHtmlPath(entryKey: string): string {
+  if (entryKey === 'index' || entryKey.endsWith('/index')) {
+    return `${entryKey}.html`
+  }
+  return `${entryKey}/index.html`
+}
+
+export function generateHtmlPlugin(visleConfig: ResolvedVisleConfig): Plugin {
+  return {
+    name: 'visle:generate-html',
+    apply: 'build',
+    sharedDuringBuild: true,
+
+    applyToEnvironment: (env) => env.name === 'generate',
+
+    resolveId(id) {
+      if (id === generateVirtualEntryId) {
+        return id
+      }
+    },
+
+    load(id) {
+      if (id === generateVirtualEntryId) {
+        return 'export default {}'
+      }
+    },
+
+    async generateBundle(_options, bundle) {
+      const root = asAbs(this.environment.config.root)
+      const serverOutDir = resolve(root, visleConfig.serverOutDir)
+      const entryDir = resolve(root, visleConfig.entryDir)
+
+      const componentIds = resolveServerComponentIds(entryDir)
+      const entryKeys = componentIds.map((id) => relative(entryDir, id).replace(/\.vue$/, ''))
+
+      const render = createRender({ serverOutDir })
+
+      const htmlResults = await Promise.all(
+        entryKeys.map(async (key) => ({
+          fileName: entryKeyToHtmlPath(key),
+          source: await render(key),
+        })),
+      )
+
+      for (const { fileName, source } of htmlResults) {
+        this.emitFile({ type: 'asset', fileName, source })
+      }
+
+      for (const key of Object.keys(bundle)) {
+        if (bundle[key]?.type === 'chunk') {
+          delete bundle[key]
+        }
+      }
+    },
+  }
+}

--- a/src/build/plugins/generate-html.ts
+++ b/src/build/plugins/generate-html.ts
@@ -1,9 +1,10 @@
 import type { Plugin } from 'vite'
+import type { ConcreteComponent } from 'vue'
 
 import { createRender } from '../../server/render.js'
 import type { ResolvedVisleConfig } from '../../shared/config.js'
-import { asAbs, relative, resolve } from '../../shared/path.js'
-import { resolveServerComponentIds } from '../paths.js'
+import { resolveServerDistPath } from '../../shared/entry.js'
+import { asAbs, resolve } from '../../shared/path.js'
 
 export const generateVirtualEntryId = '\0@visle/generate-entry'
 
@@ -12,6 +13,17 @@ export function entryKeyToHtmlPath(entryKey: string): string {
     return `${entryKey}.html`
   }
   return `${entryKey}/index.html`
+}
+
+function hasProps(component: ConcreteComponent): boolean {
+  const props = component.props
+  if (!props) {
+    return false
+  }
+  if (Array.isArray(props)) {
+    return props.length > 0
+  }
+  return Object.keys(props).length > 0
 }
 
 export function generateHtmlPlugin(visleConfig: ResolvedVisleConfig): Plugin {
@@ -37,10 +49,16 @@ export function generateHtmlPlugin(visleConfig: ResolvedVisleConfig): Plugin {
     async generateBundle(_options, bundle) {
       const root = asAbs(this.environment.config.root)
       const serverOutDir = resolve(root, visleConfig.serverOutDir)
-      const entryDir = resolve(root, visleConfig.entryDir)
 
-      const componentIds = resolveServerComponentIds(entryDir)
-      const entryKeys = componentIds.map((id) => relative(entryDir, id).replace(/\.vue$/, ''))
+      const serverEntry = await import(/* @vite-ignore */ resolveServerDistPath(serverOutDir))
+      const components: Record<string, ConcreteComponent> = serverEntry.default
+      const entryKeys = Object.keys(components)
+
+      const entriesWithProps = entryKeys.filter((key) => hasProps(components[key]!))
+      if (entriesWithProps.length > 0) {
+        const list = entriesWithProps.map((key) => `  - ${key}`).join('\n')
+        this.error(`The following entries cannot have props when using generate option:\n${list}`)
+      }
 
       const render = createRender({ serverOutDir })
 

--- a/src/build/plugins/manifest.test.ts
+++ b/src/build/plugins/manifest.test.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { beforeEach, afterEach, describe, expect, test } from 'vite-plus/test'
+import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
 import { prodBuild } from '../../../test/utils.ts'
 import { manifestFileName } from '../../shared/manifest.ts'
@@ -10,31 +10,31 @@ const generatedDir = path.resolve(import.meta.dirname, '../../../test/__generate
 
 let root: string
 
-beforeEach(() => {
-  fs.mkdirSync(generatedDir, { recursive: true })
-  root = fs.mkdtempSync(path.join(generatedDir, 'build-manifest-'))
-  fs.mkdirSync(path.join(root, 'pages'), { recursive: true })
+beforeEach(async () => {
+  await fs.mkdir(generatedDir, { recursive: true })
+  root = await fs.mkdtemp(path.join(generatedDir, 'build-manifest-'))
+  await fs.mkdir(path.join(root, 'pages'), { recursive: true })
 })
 
-afterEach(() => {
-  fs.rmSync(root, { recursive: true, force: true })
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
 })
 
 describe('build manifest CSS map', () => {
   test('collects transitive CSS', async () => {
-    fs.writeFileSync(
+    await fs.writeFile(
       path.join(root, 'pages/child-a.vue'),
       '<template><div>A</div></template><style>h1 { color: red; }</style>',
     )
-    fs.writeFileSync(
+    await fs.writeFile(
       path.join(root, 'pages/child-b.vue'),
       '<template><div>B</div><ChildC /></template><script setup>import ChildC from "./child-c.vue"</script><style>h3 { color: green; }</style>',
     )
-    fs.writeFileSync(
+    await fs.writeFile(
       path.join(root, 'pages/child-c.vue'),
       '<template><div>C</div></template><style>h2 { color: blue; }</style>',
     )
-    fs.writeFileSync(
+    await fs.writeFile(
       path.join(root, 'pages/parent.vue'),
       '<template><ChildA /><ChildB /></template><script setup>import ChildA from "./child-a.vue"\nimport ChildB from "./child-b.vue"</script>',
     )
@@ -42,7 +42,7 @@ describe('build manifest CSS map', () => {
     await prodBuild(root)
 
     const manifestPath = path.join(root, 'dist/server', manifestFileName)
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
     const cssList: string[] = manifest.cssMap['pages/parent.vue']
 
     expect(cssList).toBeDefined()

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -9,6 +9,13 @@ export interface VisleConfig {
   clientOutDir?: string
   dts?: string | null
 
+  /**
+   * When `true`, `vite build` also outputs rendered HTML files
+   * for all render entries. The HTML file paths follow the same
+   * structure as the entry `.vue` files in entryDir.
+   */
+  generate?: boolean
+
   /** @vitejs/plugin-vue options */
   vue?: Options
 }
@@ -23,6 +30,7 @@ export const defaultConfig: ResolvedVisleConfig = {
   clientOutDir: 'dist/client',
   serverOutDir: 'dist/server',
   dts: 'src/visle-generated.d.ts',
+  generate: false,
   vue: {},
 }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import { createBuilder, mergeConfig, type UserConfig } from 'vite'
 
-import { visle } from '../src/build/index.ts'
+import { type VisleConfig, visle } from '../src/build/index.ts'
 import { createDevLoader } from '../src/dev/index.ts'
 import { createRender } from '../src/server/render.ts'
 import { asRel } from '../src/shared/path.ts'
@@ -91,12 +91,16 @@ export function devRender(root: string) {
 /**
  * Run a production Vite build with additional config options.
  */
-export async function prodBuild(root: string, options: UserConfig = {}): Promise<void> {
+export async function prodBuild(
+  root: string,
+  options: UserConfig = {},
+  visleConfig: VisleConfig = {},
+): Promise<void> {
   const builder = await createBuilder(
     mergeConfig(
       {
         root,
-        plugins: [visle({ entryDir: 'pages', dts: 'visle-generated.d.ts' })],
+        plugins: [visle({ entryDir: 'pages', dts: 'visle-generated.d.ts', ...visleConfig })],
         resolve: {
           alias: {
             '@': root,


### PR DESCRIPTION
closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conditional "generate" build option to produce static HTML during production builds, preserving source directory structure for output.
  * Build will only run generation when enabled.

* **Validation**
  * Generation fails with a clear error listing entries that define props (prevents invalid static output).

* **Tests**
  * Added tests covering HTML output paths and generation behavior; updated tests to use async filesystem APIs.

* **Chores**
  * Default generate option set to off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->