### PR TITLE
ci: fix getting playwright version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Playwright version
         id: playwright-version
         shell: bash
-        run: echo "version=$(vpx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
 
       # Cache Playwright browser binaries to avoid downloading them on every run.
       # This significantly speeds up CI, especially on Windows where install takes several minutes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Playwright version
         id: playwright-version
         shell: bash
-        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(vpr playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       # Cache Playwright browser binaries to avoid downloading them on every run.
       # This significantly speeds up CI, especially on Windows where install takes several minutes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get Playwright version
         id: playwright-version
         shell: bash
-        run: echo "version=$(vpr playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(vpx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       # Cache Playwright browser binaries to avoid downloading them on every run.
       # This significantly speeds up CI, especially on Windows where install takes several minutes.


### PR DESCRIPTION
## Summary
- Replace `pnpm exec playwright --version` with `vpr playwright --version` in the CI workflow so the Playwright version lookup no longer requires pnpm to be installed on the runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ktsn/visle/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->