### PR TITLE
Add entryExt config option for custom entry extensions

### DIFF
--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -12,7 +12,7 @@ describe('generateEntryTypesCode', () => {
       asAbs('/project/pages/with-props.vue'),
     ]
 
-    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds, ['.vue'])
 
     expect(result).toContain(
       "'static': ComponentProps<typeof import('./pages/static.vue')['default']>",
@@ -27,7 +27,7 @@ describe('generateEntryTypesCode', () => {
     const dtsDir = asAbs('/project')
     const componentIds = [asAbs('/project/pages/nested/index.vue')]
 
-    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds, ['.vue'])
 
     expect(result).toContain(
       "'nested/index': ComponentProps<typeof import('./pages/nested/index.vue')['default']>",
@@ -35,7 +35,7 @@ describe('generateEntryTypesCode', () => {
   })
 
   test('handles empty component list', () => {
-    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [])
+    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [], ['.vue'])
 
     expect(result).toContain("declare module 'visle'")
     expect(result).toContain("import type { ComponentProps } from 'visle'")
@@ -47,7 +47,7 @@ describe('generateEntryTypesCode', () => {
     const dtsDir = asAbs('/project/types')
     const componentIds = [asAbs('/project/pages/static.vue')]
 
-    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds)
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds, ['.vue'])
 
     expect(result).toContain(
       "'static': ComponentProps<typeof import('../pages/static.vue')['default']>",
@@ -55,8 +55,19 @@ describe('generateEntryTypesCode', () => {
   })
 
   test('include empty export', () => {
-    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [])
+    const result = generateEntryTypesCode(asAbs('/project/pages'), asAbs('/project'), [], ['.vue'])
 
     expect(result).toContain('export {}')
+  })
+
+  test('strips multiple entry extensions', () => {
+    const entryDir = asAbs('/project/pages')
+    const dtsDir = asAbs('/project')
+    const componentIds = [asAbs('/project/pages/home.vue'), asAbs('/project/pages/post.md')]
+
+    const result = generateEntryTypesCode(entryDir, dtsDir, componentIds, ['.vue', '.md'])
+
+    expect(result).toContain("'home': ComponentProps<typeof import('./pages/home.vue')['default']>")
+    expect(result).toContain("'post': ComponentProps<typeof import('./pages/post.md')['default']>")
   })
 })

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -1,4 +1,5 @@
 import { type AbsolutePath, type RelativePath, relative } from '../shared/path.js'
+import { stripEntryExt } from './paths.js'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
 
@@ -7,12 +8,13 @@ export const componentWrapPrefix = '\0visle:wrap:'
 export function generateServerVirtualEntryCode(
   entryDir: AbsolutePath,
   componentIds: AbsolutePath[],
+  entryExt: string[],
 ): string {
   const imports = componentIds.map((id, i) => `import _${i} from '${id}'`).join('\n')
 
   const entries = componentIds
     .map((id, i) => {
-      const key = relative(entryDir, id).replace(/\.vue$/, '')
+      const key = stripEntryExt(relative(entryDir, id), entryExt)
       return `  '${key}': _${i}`
     })
     .join(',\n')
@@ -62,10 +64,11 @@ export function generateEntryTypesCode(
   entryDir: AbsolutePath,
   dtsDir: AbsolutePath,
   componentIds: AbsolutePath[],
+  entryExt: string[],
 ): string {
   const entries = componentIds
     .map((id) => {
-      const key = relative(entryDir, id).replace(/\.vue$/, '')
+      const key = stripEntryExt(relative(entryDir, id), entryExt)
       const importPath = relative(dtsDir, id)
       const importSpecifier = importPath.startsWith('.') ? importPath : `./${importPath}`
       return `    '${key}': ComponentProps<typeof import('${importSpecifier}')['default']>`

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -29,7 +29,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     ...config,
   }
 
-  const { plugin: serverTransform, islandPaths } = serverTransformPlugin()
+  const { plugin: serverTransform, islandPaths } = serverTransformPlugin(resolvedConfig.entryExt)
   const virtualFile = virtualFilePlugin(resolvedConfig)
   const { plugin: manifest, getManifestData } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
@@ -50,7 +50,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             build: {
               outDir: resolvedConfig.clientOutDir,
               rollupOptions: {
-                input: [...resolveServerComponentIds(entryDir)],
+                input: [...resolveServerComponentIds(entryDir, resolvedConfig.entryExt)],
                 preserveEntrySignatures: 'allow-extension',
               },
             },

--- a/src/build/paths.test.ts
+++ b/src/build/paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vite-plus/test'
 
 import { componentWrapPrefix } from './generate.js'
-import { parseId } from './paths.js'
+import { hasEntryExt, parseId, stripEntryExt } from './paths.js'
 
 describe('parseId', () => {
   test('plain file path', () => {
@@ -50,5 +50,33 @@ describe('parseId', () => {
       query: { names: ['A', 'B'] },
       prefix: undefined,
     })
+  })
+})
+
+describe('hasEntryExt', () => {
+  test('matches single extension', () => {
+    expect(hasEntryExt('/foo/bar.vue', ['.vue'])).toBe(true)
+  })
+
+  test('matches one of multiple extensions', () => {
+    expect(hasEntryExt('/foo/bar.md', ['.vue', '.md'])).toBe(true)
+  })
+
+  test('returns false for non-matching extension', () => {
+    expect(hasEntryExt('/foo/bar.ts', ['.vue', '.md'])).toBe(false)
+  })
+})
+
+describe('stripEntryExt', () => {
+  test('strips matching extension', () => {
+    expect(stripEntryExt('foo/bar.vue', ['.vue'])).toBe('foo/bar')
+  })
+
+  test('strips first matching extension from multiple', () => {
+    expect(stripEntryExt('foo/bar.md', ['.vue', '.md'])).toBe('foo/bar')
+  })
+
+  test('returns path unchanged if no extension matches', () => {
+    expect(stripEntryExt('foo/bar.ts', ['.vue', '.md'])).toBe('foo/bar.ts')
   })
 })

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -76,8 +76,33 @@ export function parseId(id: string): {
 }
 
 /**
+ * Check if a path has one of the configured entry extensions
+ */
+export function hasEntryExt(filePath: string, entryExt: string[]): boolean {
+  return entryExt.some((ext) => filePath.endsWith(ext))
+}
+
+/**
+ * Strip a matching entry extension from a path
+ */
+export function stripEntryExt(filePath: string, entryExt: string[]): string {
+  for (const ext of entryExt) {
+    if (filePath.endsWith(ext)) {
+      return filePath.slice(0, -ext.length)
+    }
+  }
+  return filePath
+}
+
+/**
  * Resolves paths for all server components
  */
-export function resolveServerComponentIds(entryDir: AbsolutePath): AbsolutePath[] {
-  return resolvePattern('/**/*.vue', entryDir)
+export function resolveServerComponentIds(
+  entryDir: AbsolutePath,
+  entryExt: string[],
+): AbsolutePath[] {
+  return resolvePattern(
+    entryExt.map((ext) => `/**/*${ext}`),
+    entryDir,
+  )
 }

--- a/src/build/plugins/entry-types.test.ts
+++ b/src/build/plugins/entry-types.test.ts
@@ -17,9 +17,13 @@ vi.mock('node:fs/promises', () => ({
   },
 }))
 
-vi.mock('../paths.ts', () => ({
-  resolveServerComponentIds: vi.fn(() => []),
-}))
+vi.mock('../paths.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../paths.ts')>()
+  return {
+    ...actual,
+    resolveServerComponentIds: vi.fn(() => []),
+  }
+})
 
 function createPlugin(dts: string | null = defaultConfig.dts) {
   const { plugin, generate } = entryTypesPlugin({
@@ -61,7 +65,7 @@ describe('entryTypesPlugin', () => {
     const hook = plugin.configureServer as (server: ViteDevServer) => Promise<void>
     await hook(createServer(watcher))
 
-    expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages')
+    expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages', ['.vue'])
     expect(fs.writeFile).toHaveBeenCalledWith(
       '/project/src/visle-generated.d.ts',
       expect.stringMatching('Index'),
@@ -75,7 +79,7 @@ describe('entryTypesPlugin', () => {
 
     await generate()
 
-    expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages')
+    expect(resolveServerComponentIds).toHaveBeenCalledWith('/project/src/pages', ['.vue'])
     expect(fs.writeFile).toHaveBeenCalledWith(
       '/project/src/visle-generated.d.ts',
       expect.stringMatching('Index'),

--- a/src/build/plugins/entry-types.ts
+++ b/src/build/plugins/entry-types.ts
@@ -5,7 +5,7 @@ import type { Plugin } from 'vite'
 import type { ResolvedVisleConfig } from '../../shared/config.js'
 import { type AbsolutePath, asAbs, dirname, resolve } from '../../shared/path.js'
 import { generateEntryTypesCode } from '../generate.js'
-import { resolveServerComponentIds } from '../paths.js'
+import { hasEntryExt, resolveServerComponentIds } from '../paths.js'
 
 /**
  * Plugin that generates the d.ts file.
@@ -29,9 +29,9 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
   let lastContent: string | undefined
 
   async function generateAndWrite(): Promise<void> {
-    const componentIds = resolveServerComponentIds(entryRoot)
+    const componentIds = resolveServerComponentIds(entryRoot, config.entryExt)
     const dtsDir = dirname(dtsPath)
-    const content = generateEntryTypesCode(entryRoot, dtsDir, componentIds)
+    const content = generateEntryTypesCode(entryRoot, dtsDir, componentIds, config.entryExt)
 
     if (content === lastContent) {
       return
@@ -62,7 +62,7 @@ export function entryTypesPlugin(config: ResolvedVisleConfig): {
 
     async configureServer(server) {
       const onChange = (filePath: string) => {
-        if (filePath.endsWith('.vue') && filePath.startsWith(entryRoot)) {
+        if (hasEntryExt(filePath, config.entryExt) && filePath.startsWith(entryRoot)) {
           scheduleGenerate(() => {
             this.warn(`Failed to generate a dts file to ${config.dts!}`)
           })

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -141,6 +141,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
       return {
         base,
         entryDir: visleConfig.entryDir,
+        entryExt: visleConfig.entryExt,
         cssMap: Object.fromEntries(cssMap ?? new Map()),
         jsMap: Object.fromEntries(jsMap ?? new Map()),
         islandsBootstrap: islandsBootstrap ?? '',

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -3,7 +3,7 @@ import { parse } from 'vue/compiler-sfc'
 
 import { asAbs, relative } from '../../shared/path.js'
 import { generateComponentWrapperCode, componentWrapPrefix } from '../generate.js'
-import { parseId } from '../paths.js'
+import { hasEntryExt, parseId } from '../paths.js'
 import { buildImportMap, findVClientElements } from '../sfc-analysis.js'
 
 interface ServerTransformPluginResult {
@@ -17,7 +17,7 @@ interface ServerTransformPluginResult {
  * - Loads wrapper virtual modules with generated code
  * - Detects `v-client:load` directives and collects island component paths for the islands build
  */
-export function serverTransformPlugin(): ServerTransformPluginResult {
+export function serverTransformPlugin(entryExt: string[]): ServerTransformPluginResult {
   const islandPaths = new Set<string>()
 
   /**
@@ -57,8 +57,8 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
 
       const { fileName, query } = parseId(id)
 
-      // Skip .vue sub-requests (e.g. ?vue&type=script)
-      if (fileName.endsWith('.vue') && query.vue) {
+      // Skip SFC sub-requests (e.g. ?vue&type=script)
+      if (hasEntryExt(fileName, entryExt) && query.vue) {
         return null
       }
 
@@ -98,11 +98,11 @@ export function serverTransformPlugin(): ServerTransformPluginResult {
     async transform(code, id) {
       const { fileName, query } = parseId(id)
 
-      if (!fileName.endsWith('.vue')) {
+      if (!hasEntryExt(fileName, entryExt)) {
         return null
       }
 
-      // Skip sub-requests (e.g., ?vue&type=style) — only process plain .vue files
+      // Skip sub-requests (e.g., ?vue&type=style) — only process plain SFC files
       if (query.vue) {
         return null
       }

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -32,7 +32,11 @@ export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
 
     load(id) {
       if (id === serverVirtualEntryId) {
-        return generateServerVirtualEntryCode(entryRoot, resolveServerComponentIds(entryRoot))
+        return generateServerVirtualEntryCode(
+          entryRoot,
+          resolveServerComponentIds(entryRoot, config.entryExt),
+          config.entryExt,
+        )
       }
 
       return null

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -62,22 +62,28 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
 
       const visleConfig = getVisleConfig(devServer.config)
 
-      const modulePath = resolve(
-        asAbs(devServer.config.root),
-        visleConfig.entryDir,
-        `${componentPath}.vue`,
-      )
+      const root = asAbs(devServer.config.root)
+      const serverEnv = getServerEnvironment(devServer)
 
-      try {
-        const serverEnv = getServerEnvironment(devServer)
-        const module = await serverEnv.runner.import(modulePath)
-        return module.default
-      } catch (e) {
-        if (e instanceof Error) {
-          devServer.ssrFixStacktrace(e)
+      // Try each extension sequentially, returning the first successful import
+      for (const ext of visleConfig.entryExt) {
+        const modulePath = resolve(root, visleConfig.entryDir, `${componentPath}${ext}`)
+        try {
+          // oxlint-disable-next-line no-await-in-loop
+          const module = await serverEnv.runner.import(modulePath)
+          return module.default
+        } catch (e) {
+          if (e instanceof Error) {
+            devServer.ssrFixStacktrace(e)
+          }
+          // Try next extension
+          continue
         }
-        throw e
       }
+
+      throw new Error(
+        `Entry component not found: ${componentPath} (tried extensions: ${visleConfig.entryExt.join(', ')})`,
+      )
     },
 
     async getManifest() {

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import { existsSync } from 'node:fs'
 
 import connect from 'connect'
 import { Connect, createServer, InlineConfig, isRunnableDevEnvironment } from 'vite'
@@ -7,7 +8,7 @@ import type { RunnableDevEnvironment, ViteDevServer } from 'vite'
 import { RuntimeManifest } from '../server/manifest.js'
 import { RenderLoader } from '../server/render.js'
 import { getVisleConfig } from '../shared/config.js'
-import { asAbs, resolve } from '../shared/path.js'
+import { asAbs, AbsolutePath, resolve } from '../shared/path.js'
 import { createDevManifest } from './manifest.js'
 
 interface DevRenderLoader extends RenderLoader {
@@ -63,27 +64,36 @@ export function createDevLoader(viteConfig: InlineConfig = {}): DevRenderLoader 
       const visleConfig = getVisleConfig(devServer.config)
 
       const root = asAbs(devServer.config.root)
+      const entryDir = resolve(root, visleConfig.entryDir)
       const serverEnv = getServerEnvironment(devServer)
 
-      // Try each extension sequentially, returning the first successful import
+      // Resolve the entry file by checking the filesystem first, so that
+      // an import error (e.g. syntax error in an existing file) is not
+      // mistaken for a missing file and silently swallowed.
+      let modulePath: AbsolutePath | undefined
       for (const ext of visleConfig.entryExt) {
-        const modulePath = resolve(root, visleConfig.entryDir, `${componentPath}${ext}`)
-        try {
-          // oxlint-disable-next-line no-await-in-loop
-          const module = await serverEnv.runner.import(modulePath)
-          return module.default
-        } catch (e) {
-          if (e instanceof Error) {
-            devServer.ssrFixStacktrace(e)
-          }
-          // Try next extension
-          continue
+        const candidate = resolve(entryDir, `${componentPath}${ext}`)
+        if (existsSync(candidate)) {
+          modulePath = candidate
+          break
         }
       }
 
-      throw new Error(
-        `Entry component not found: ${componentPath} (tried extensions: ${visleConfig.entryExt.join(', ')})`,
-      )
+      if (!modulePath) {
+        throw new Error(
+          `Entry component not found: ${componentPath} (tried extensions: ${visleConfig.entryExt.join(', ')})`,
+        )
+      }
+
+      try {
+        const module = await serverEnv.runner.import(modulePath)
+        return module.default
+      } catch (e) {
+        if (e instanceof Error) {
+          devServer.ssrFixStacktrace(e)
+        }
+        throw e
+      }
     },
 
     async getManifest() {

--- a/src/dev/manifest.ts
+++ b/src/dev/manifest.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import { type EnvironmentModuleNode, type ViteDevServer } from 'vite'
 import { parse, SFCBlock } from 'vue/compiler-sfc'
 
+import { hasEntryExt } from '../build/paths.js'
 import { type RuntimeManifest } from '../server/manifest.js'
 import { generateComponentId } from '../shared/component-id.js'
 import { getVisleConfig } from '../shared/config.js'
@@ -19,7 +20,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
 
   const root = asAbs(devServer.config.root)
   const { base } = devServer.config
-  const { entryDir } = getVisleConfig(devServer.config)
+  const { entryDir, entryExt } = getVisleConfig(devServer.config)
 
   // Normalize origin value
   const origin = devServer.config.server.origin?.replace(/\/$/, '') ?? ''
@@ -32,7 +33,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
   async function getComponentCssIds(componentRelativePath: string): Promise<string[]> {
     const absPath = resolve(root, componentRelativePath)
 
-    if (!absPath.endsWith('.vue')) {
+    if (!hasEntryExt(absPath, entryExt)) {
       return []
     }
 
@@ -85,18 +86,29 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
     },
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {
-      const entryRelativePath = `${entryDir}/${componentPath}.vue`
-      const entryAbsPath = resolve(root, entryRelativePath)
-
-      const entryMod = serverEnv.moduleGraph.getModuleById(entryAbsPath)
-      if (!entryMod) {
-        // Module not yet loaded in the module graph, fall back to parsing the entry file
-        return getComponentCssIds(entryRelativePath)
+      // Find the entry module in the module graph by trying each extension
+      let entryRelativePath: string | undefined
+      let entryMod: EnvironmentModuleNode | undefined
+      for (const ext of entryExt) {
+        const candidate = `${entryDir}/${componentPath}${ext}`
+        const candidateAbs = resolve(root, candidate)
+        const mod = serverEnv.moduleGraph.getModuleById(candidateAbs)
+        if (mod) {
+          entryRelativePath = candidate
+          entryMod = mod
+          break
+        }
       }
 
-      // Walk module graph to find all transitively imported .vue and CSS files
+      if (!entryMod || !entryRelativePath) {
+        // Module not yet loaded in the module graph, fall back to parsing the first matching entry file
+        const fallbackPath = `${entryDir}/${componentPath}${entryExt[0]}`
+        return getComponentCssIds(fallbackPath)
+      }
+
+      // Walk module graph to find all transitively imported SFC and CSS files
       // preserving discovery order
-      const discovered: ({ type: 'css'; id: string } | { type: 'vue'; relativePath: string })[] = []
+      const discovered: ({ type: 'css'; id: string } | { type: 'sfc'; relativePath: string })[] = []
       const visited = new Set<string>()
 
       const walk = (mod: EnvironmentModuleNode) => {
@@ -105,9 +117,9 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
         }
         visited.add(mod.id)
 
-        if (mod.id.endsWith('.vue')) {
+        if (hasEntryExt(mod.id, entryExt)) {
           discovered.push({
-            type: 'vue',
+            type: 'sfc',
             relativePath: relative(root, asAbs(mod.id)),
           })
         } else if (!mod.id.includes('?vue') && isCSS(mod.id)) {

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -24,6 +24,7 @@ describe('loadManifest', () => {
   function writeManifest(data: {
     base?: string
     entryDir?: string
+    entryExt?: string[]
     cssMap?: Record<string, string[]>
     jsMap?: Record<string, string>
   }): void {
@@ -32,6 +33,7 @@ describe('loadManifest', () => {
       JSON.stringify({
         base: '/',
         entryDir: 'src/pages',
+        entryExt: ['.vue'],
         cssMap: {},
         jsMap: {},
         ...data,
@@ -98,5 +100,29 @@ describe('loadManifest', () => {
     const result = await manifest.getEntryCssIds('index')
 
     expect(result).toEqual(['/index-1234.css'])
+  })
+
+  test('getEntryCssIds resolves custom entry extension', async () => {
+    writeManifest({
+      entryExt: ['.vue', '.md'],
+      cssMap: { 'src/pages/post.md': ['post-1234.css'] },
+    })
+
+    const manifest = await loadManifest(asAbs(root))
+    const result = await manifest.getEntryCssIds('post')
+
+    expect(result).toEqual(['/post-1234.css'])
+  })
+
+  test('getEntryCssIds returns empty array when no extension matches', async () => {
+    writeManifest({
+      entryExt: ['.vue'],
+      cssMap: {},
+    })
+
+    const manifest = await loadManifest(asAbs(root))
+    const result = await manifest.getEntryCssIds('nonexistent')
+
+    expect(result).toEqual([])
   })
 })

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -28,9 +28,15 @@ export async function loadManifest(serverOutDir: AbsolutePath): Promise<RuntimeM
     },
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {
-      const entryRelativePath = `${data.entryDir}/${componentPath}.vue`
-      const cssIds = data.cssMap[entryRelativePath] ?? []
-      return cssIds.map((cssId) => `${basePath}/${cssId}`)
+      const entryExt = data.entryExt ?? ['.vue']
+      for (const ext of entryExt) {
+        const entryRelativePath = `${data.entryDir}/${componentPath}${ext}`
+        const cssIds = data.cssMap[entryRelativePath]
+        if (cssIds) {
+          return cssIds.map((cssId) => `${basePath}/${cssId}`)
+        }
+      }
+      return []
     },
 
     async getIslandsBootstrapId(): Promise<string> {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -5,6 +5,7 @@ import type { Options } from '@vitejs/plugin-vue'
  */
 export interface VisleConfig {
   entryDir?: string
+  entryExt?: string[]
   serverOutDir?: string
   clientOutDir?: string
   dts?: string | null
@@ -20,6 +21,7 @@ export type ResolvedVisleConfig = Required<VisleConfig>
 
 export const defaultConfig: ResolvedVisleConfig = {
   entryDir: 'src/pages',
+  entryExt: ['.vue'],
   clientOutDir: 'dist/client',
   serverOutDir: 'dist/server',
   dts: 'src/visle-generated.d.ts',

--- a/src/shared/manifest.ts
+++ b/src/shared/manifest.ts
@@ -3,6 +3,7 @@ export const manifestFileName = 'visle-manifest.json'
 export interface ManifestData {
   base: string
   entryDir: string
+  entryExt: string[]
   cssMap: Record<string, string[]>
   jsMap: Record<string, string>
   islandsBootstrap: string

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -311,6 +311,17 @@ exports[`Dev Server SSR > 'Island with props' 1`] = `
 </div>
 `;
 
+exports[`Dev Server SSR > 'Markdown entry component' 1`] = `
+<div>
+  <h1>
+    Hello Markdown
+  </h1>
+  <p>
+    This is a markdown entry rendered as a Vue component.
+  </p>
+</div>
+`;
+
 exports[`Dev Server SSR > 'Multiple islands on the same page' 1`] = `
 <script
   type="module"
@@ -520,6 +531,7 @@ declare module 'visle' {
     'named-export': ComponentProps<typeof import('./pages/named-export.vue')['default']>
     'document': ComponentProps<typeof import('./pages/document.vue')['default']>
     'nested/index': ComponentProps<typeof import('./pages/nested/index.vue')['default']>
+    'markdown-page': ComponentProps<typeof import('./pages/markdown-page.md')['default']>
   }
 }
 export {}

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -559,6 +559,9 @@ exports[`Production Build SSR > Build output files 2`] = `
     "pages/with-visible-island.vue": [],
   },
   "entryDir": "pages",
+  "entryExt": [
+    ".vue",
+  ],
   "islandsBootstrap": "assets/custom-element-[hash].js",
   "jsMap": {
     "components/AliasStyledCounter.vue": "assets/AliasStyledCounter-[hash].js",

--- a/test/__snapshots__/prod.test.ts.snap
+++ b/test/__snapshots__/prod.test.ts.snap
@@ -303,6 +303,17 @@ exports[`Production Build SSR > 'Island with props' 1`] = `
 </div>
 `;
 
+exports[`Production Build SSR > 'Markdown entry component' 1`] = `
+<div>
+  <h1>
+    Hello Markdown
+  </h1>
+  <p>
+    This is a markdown entry rendered as a Vue component.
+  </p>
+</div>
+`;
+
 exports[`Production Build SSR > 'Multiple islands on the same page' 1`] = `
 <script
   type="module"
@@ -511,6 +522,7 @@ exports[`Production Build SSR > Build output files 2`] = `
   "base": "/",
   "cssMap": {
     "pages/document.vue": [],
+    "pages/markdown-page.md": [],
     "pages/named-export.vue": [],
     "pages/nested/index.vue": [],
     "pages/non-ascii-テスト.vue": [],
@@ -561,6 +573,7 @@ exports[`Production Build SSR > Build output files 2`] = `
   "entryDir": "pages",
   "entryExt": [
     ".vue",
+    ".md",
   ],
   "islandsBootstrap": "assets/custom-element-[hash].js",
   "jsMap": {
@@ -619,6 +632,7 @@ declare module 'visle' {
     'named-export': ComponentProps<typeof import('./pages/named-export.vue')['default']>
     'document': ComponentProps<typeof import('./pages/document.vue')['default']>
     'nested/index': ComponentProps<typeof import('./pages/nested/index.vue')['default']>
+    'markdown-page': ComponentProps<typeof import('./pages/markdown-page.md')['default']>
   }
 }
 export {}

--- a/test/fixtures/pages/markdown-page.md
+++ b/test/fixtures/pages/markdown-page.md
@@ -1,0 +1,3 @@
+# Hello Markdown
+
+This is a markdown entry rendered as a Vue component.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { createBuilder, mergeConfig, type UserConfig } from 'vite'
+import { createBuilder, mergeConfig, type Plugin, type UserConfig } from 'vite'
 
 import { visle } from '../src/build/index.ts'
 import { createDevLoader } from '../src/dev/index.ts'
@@ -39,7 +39,44 @@ export const renderCases: { name: string; component: string; props?: Record<stri
   { name: 'Dynamic import shared CSS', component: 'with-dynamic-shared-css' },
   { name: 'CSS import in script', component: 'with-css-import' },
   { name: 'SVG image asset', component: 'with-svg-img' },
+  { name: 'Markdown entry component', component: 'markdown-page' },
 ]
+
+const entryExt = ['.vue', '.md']
+const vueInclude = [/\.vue$/, /\.md$/]
+
+/**
+ * Test-only plugin that converts `.md` files into Vue SFC text in the load
+ * phase, so the rest of the pipeline (visle's server transform and
+ * @vitejs/plugin-vue) can treat them as ordinary SFCs. Used to exercise the
+ * `entryExt` config with a non-`.vue` extension.
+ */
+function markdownToVuePlugin(): Plugin {
+  return {
+    name: 'test:markdown-to-vue',
+    enforce: 'pre',
+    async load(id) {
+      const [fileName, query] = id.split('?')
+      if (!fileName?.endsWith('.md')) return null
+      // Skip sub-requests emitted by the Vue plugin (e.g. ?vue&type=script)
+      if (query?.includes('vue')) return null
+
+      const md = await fs.readFile(fileName, 'utf-8')
+      const html = md
+        .split('\n')
+        .map((line) => {
+          const trimmed = line.trim()
+          if (trimmed === '') return ''
+          if (trimmed.startsWith('# ')) return `<h1>${trimmed.slice(2)}</h1>`
+          return `<p>${trimmed}</p>`
+        })
+        .filter(Boolean)
+        .join('')
+
+      return `<template><div>${html}</div></template>`
+    },
+  }
+}
 
 /**
  * Create a unique temporary directory for a test suite.
@@ -74,7 +111,15 @@ export function devRender(root: string) {
 
   const loader = createDevLoader({
     root,
-    plugins: [visle({ entryDir: 'pages', dts: 'visle-generated.d.ts' })],
+    plugins: [
+      markdownToVuePlugin(),
+      visle({
+        entryDir: 'pages',
+        entryExt,
+        dts: 'visle-generated.d.ts',
+        vue: { include: vueInclude },
+      }),
+    ],
     resolve: {
       alias: {
         '@': root,
@@ -96,7 +141,15 @@ export async function prodBuild(root: string, options: UserConfig = {}): Promise
     mergeConfig(
       {
         root,
-        plugins: [visle({ entryDir: 'pages', dts: 'visle-generated.d.ts' })],
+        plugins: [
+          markdownToVuePlugin(),
+          visle({
+            entryDir: 'pages',
+            entryExt,
+            dts: 'visle-generated.d.ts',
+            vue: { include: vueInclude },
+          }),
+        ],
         resolve: {
           alias: {
             '@': root,


### PR DESCRIPTION
## Summary

- Add a new `entryExt` config option (defaults to `['.vue']`) so entry components can use extensions other than `.vue`. The extension list is threaded through component resolution, server transforms, dev loader, manifest generation, and entry types.
- In the dev loader, check entry file existence first and let import errors propagate, so a syntax error in an existing entry no longer gets silently swallowed and reported as "Entry component not found".
- Cover non-`.vue` entries in the test harness by wiring `.md` into both dev and prod `renderCases` via a load-phase plugin that converts markdown to Vue SFC text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable entry file extensions (`entryExt`) to support component entry types beyond Vue files, such as Markdown. Defaults to `.vue` for backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ktsn/visle/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->