### PR TITLE
docs: document entryExt config option

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -119,6 +119,15 @@ interface VisleConfig {
   entryDir?: string
 
   /**
+   * File extensions used to detect entry components in `entryDir`.
+   * Each extension must include the leading dot. To support non-`.vue`
+   * sources (e.g. `.md`), add a Vite plugin that transforms them into
+   * Vue SFC text at the `load` phase.
+   * Default: ['.vue']
+   */
+  entryExt?: string[]
+
+  /**
    * Output directory for server build.
    * Default: 'dist/server'
    */


### PR DESCRIPTION
## Summary

- Add documentation for the `entryExt` option in the `VisleConfig` block of the API reference, including the dot-prefix requirement and the `load`-phase plugin pattern needed for non-`.vue` sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API documentation with new optional `entryExt` configuration setting, allowing customization of file extensions detected in entry directories (default: `['.vue']`).
  * Added guidance on supporting non-Vue file sources through Vite plugin configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ktsn/visle/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->