### PR TITLE
feat!: add `createStaticLoader` instead of default dynamic loader for renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           run-install: true
 
       - run: vp run -r build
+      - run: vp run ec-site-example#check:worker
       - run: vp check
 
   publish-dry-run:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __generated__/
 coverage/
 *.tsbuildinfo
 visle-generated.d.ts
+.wrangler/

--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ Create a server file (e.g. `server.ts`) that uses `createRender()` to render pag
 ```ts
 // server.ts
 import express from 'express'
-import { createRender } from 'visle'
+import { createRender, createStaticLoader } from 'visle'
+import runtime from './dist/server/visle-runtime.js'
 
 const app = express()
 
 // Visle's render function
-const render = createRender()
+const render = createRender({ loader: createStaticLoader(runtime) })
 
 // Serve client assets built with Vite
 app.use('/assets', express.static('dist/client/assets'))

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,9 +7,10 @@
 Creates a render function that renders Vue components to HTML strings.
 
 ```ts
-import { createRender } from 'visle'
+import { createRender, createStaticLoader } from 'visle'
+import runtime from './dist/server/visle-runtime.js'
 
-const render = createRender()
+const render = createRender({ loader: createStaticLoader(runtime) })
 const html = await render('index', { title: 'Hello' })
 ```
 
@@ -17,12 +18,7 @@ const html = await render('index', { title: 'Hello' })
 
 ```ts
 interface RenderOptions {
-  /**
-   * Directory path for server build output.
-   * Pass the same value as the Visle plugin's `serverOutDir`.
-   * Default: 'dist/server'
-   */
-  serverOutDir?: string
+  loader?: RenderLoader
 }
 ```
 
@@ -33,10 +29,29 @@ interface RenderFunction<T> {
   // Render a component to an HTML string
   <K extends keyof T>(componentPath: K, ...args: RenderArgs<T[K]>): Promise<string>
 
-  // Set a custom loader (used in development)
+  // Install or replace the environment-specific loader
   setLoader(loader: RenderLoader): void
 }
 ```
+
+When creating a renderer without a loader, its environment entry point must call `setLoader()` before handling a request. Rendering earlier throws:
+
+```text
+[visle] Render loader is not configured. Call render.setLoader(loader) before rendering.
+```
+
+### `createStaticLoader(runtime)`
+
+Creates a platform-neutral production loader from the generated static runtime module.
+
+```ts
+import { createStaticLoader } from 'visle'
+import runtime from './dist/server/visle-runtime.js'
+
+render.setLoader(createStaticLoader(runtime))
+```
+
+The Vite build writes `visle-runtime.js` beside the server entry. It statically imports both the emitted server entry and `visle-manifest.json` so deployment bundlers can discover the complete runtime artifact graph.
 
 ### `VisleEntries`
 

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -4,48 +4,42 @@ Visle provides a dev loader that integrates with Vite's dev server for hot modul
 
 ## Setting Up the Dev Loader
 
-Use `createDevLoader()` from `visle/dev` to create a development loader and connect it to your render function with `setLoader()`:
+Application and route definitions can own one shared renderer without importing development-only dependencies:
 
 ```ts
-import { createRender } from 'visle'
-import { createDevLoader } from 'visle/dev'
-
-const render = createRender()
-
-// Create and set the dev loader
-const loader = createDevLoader()
-render.setLoader(loader)
-```
-
-The loader also provides a Connect-compatible middleware for serving Vite's development assets. Add `loader.middleware` to your server:
-
-```ts
+// src/app.ts
 import express from 'express'
 import { createRender } from 'visle'
-import { createDevLoader } from 'visle/dev'
 
 const app = express()
-
 const render = createRender()
-
-if (process.env.NODE_ENV === 'production') {
-  // Serve client assets built with Vite in production
-  app.use('/assets', express.static('dist/client/assets'))
-} else {
-  // Set dev loader and serve Vite dev assets in development
-  const loader = createDevLoader()
-  render.setLoader(loader)
-
-  app.use(loader.middleware)
-}
 
 app.get('/', async (req, res) => {
   const html = await render('index')
   res.send(html)
 })
 
+export { app, render }
+```
+
+The development-only entry imports `createDevLoader()` from `visle/dev` and installs it before serving requests. The loader also provides Connect-compatible middleware for serving Vite's development assets:
+
+```ts
+// src/dev.ts
+import { createDevLoader } from 'visle/dev'
+
+import { app, render } from './app.ts'
+
+// Set dev loader and serve Vite dev assets in development
+const loader = createDevLoader()
+
+render.setLoader(loader)
+app.use(loader.middleware)
+
 app.listen(3000)
 ```
+
+Only `src/dev.ts` imports `visle/dev` and therefore Vite. The production entry can import the same renderer and install the static production loader described in the [production guide](./production.md).
 
 ## Custom Vite Config
 

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -1,15 +1,15 @@
 # Production
 
-In production, Visle serves pre-built assets from the Vite build output.
+In production, Visle renders from a statically imported build artifact.
 
 ## Build Output
 
 Running `vite build` produces two directories:
 
 - **`dist/client`** (default) — Client-side assets (CSS, island JavaScript)
-- **`dist/server`** (default) — Server-side components for HTML rendering and the asset manifest
+- **`dist/server`** (default) — Server-side components, `visle-manifest.json`, and `visle-runtime.js`
 
-You can customize these paths in the Visle plugin config:
+You can customize the output paths in the Visle plugin config:
 
 ```ts
 import { visle } from 'visle/build'
@@ -25,36 +25,42 @@ export default defineConfig({
 })
 ```
 
-## Serving Static Assets
+## Configure the Production Loader
 
-Serve the `dist/client` directory as static files so that CSS and island JavaScript are available to the browser:
+Application and route definitions can own one shared renderer without knowing their environment:
 
 ```ts
+// src/app.ts
 import express from 'express'
 import { createRender } from 'visle'
 
 const app = express()
 const render = createRender()
 
-// Serve the built assets
-app.use('/assets', express.static('dist/client/assets'))
-
 app.get('/', async (req, res) => {
   const html = await render('index')
   res.send(html)
 })
 
+export { app, render }
+```
+
+The production entry imports the generated runtime and installs its loader before serving requests:
+
+```ts
+// src/prod.ts
+import express from 'express'
+import { createStaticLoader } from 'visle'
+import runtime from '../dist/server/visle-runtime.js'
+
+import { app, render } from './app.ts'
+
+render.setLoader(createStaticLoader(runtime))
+
+// Serve the built assets
+app.use('/assets', express.static('dist/client/assets'))
+
 app.listen(3000)
 ```
 
-## Custom `serverOutDir`
-
-If you customize `serverOutDir` in the Visle plugin, pass the same value to `createRender()`:
-
-```ts
-const render = createRender({
-  serverOutDir: 'custom/server',
-})
-```
-
-This tells the render function where to find the pre-built server components and manifest.
+If `serverOutDir` is customized, update the static runtime import path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,12 +81,13 @@ Create a server file (e.g. `server.ts`) that uses `createRender()` to render pag
 ```ts
 // server.ts
 import express from 'express'
-import { createRender } from 'visle'
+import { createRender, createStaticLoader } from 'visle'
+import runtime from './dist/server/visle-runtime.js'
 
 const app = express()
 
 // Visle's render function
-const render = createRender()
+const render = createRender({ loader: createStaticLoader(runtime) })
 
 // Serve client assets built with Vite
 app.use('/assets', express.static('dist/client/assets'))

--- a/examples/ec-site/package.json
+++ b/examples/ec-site/package.json
@@ -5,16 +5,19 @@
   "scripts": {
     "dev": "node src/dev.ts",
     "build": "vp build",
-    "start": "node src/prod.ts"
+    "start": "wrangler dev",
+    "check:worker": "wrangler deploy --dry-run",
+    "deploy:worker": "wrangler deploy"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.9",
     "hono": "^4.11.9",
     "visle": "workspace:*",
     "vue": "^3.5.28"
   },
   "devDependencies": {
+    "@hono/node-server": "^1.19.9",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "wrangler": "^4.118.0"
   }
 }

--- a/examples/ec-site/src/prod.ts
+++ b/examples/ec-site/src/prod.ts
@@ -1,10 +1,8 @@
-import { serve } from '@hono/node-server'
-import { serveStatic } from '@hono/node-server/serve-static'
+import { createStaticLoader } from 'visle'
 
-import { app } from './app/server.ts'
+import runtime from '../dist/server/visle-runtime.js'
+import { app, render } from './app/server.ts'
 
-app.use('/assets/*', serveStatic({ root: 'dist/client' }))
+render.setLoader(createStaticLoader(runtime))
 
-serve({ fetch: app.fetch, port: 3000 }, () => {
-  console.log('Server running at http://localhost:3000')
-})
+export default app

--- a/examples/ec-site/wrangler.jsonc
+++ b/examples/ec-site/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "visle-ec-site-example",
+  "main": "src/prod.ts",
+  "compatibility_date": "2026-08-04",
+  "build": {
+    "command": "vp build",
+    "watch_dir": ["src/app", "src/components", "src/pages"],
+  },
+  "assets": {
+    "directory": "./dist/client",
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
     dependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.3
-        version: 6.0.8(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))
+        version: 6.0.8(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))
       '@vue/compiler-core':
         specifier: ^3.5.28
         version: 3.5.40
@@ -73,25 +73,22 @@ importers:
         version: 7.0.2
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.7
-        version: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+        version: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
       vitepress:
         specifier: 2.0.0-alpha.18
-        version: 2.0.0-alpha.18(@types/node@25.9.5)(jiti@2.7.0)(postcss@8.5.25)(typescript@7.0.2)(yaml@2.9.0)
+        version: 2.0.0-alpha.18(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.25)(typescript@7.0.2)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
+        version: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
       vue:
         specifier: 3.5.40
         version: 3.5.40(typescript@7.0.2)
 
   examples/ec-site:
     dependencies:
-      '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.17(hono@4.12.33)
       hono:
         specifier: ^4.11.9
         version: 4.12.33
@@ -102,12 +99,18 @@ importers:
         specifier: ^3.5.28
         version: 3.5.40(typescript@7.0.2)
     devDependencies:
+      '@hono/node-server':
+        specifier: ^1.19.9
+        version: 1.19.17(hono@4.12.33)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.7
-        version: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+        version: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+      wrangler:
+        specifier: ^4.118.0
+        version: 4.118.0
 
 packages:
 
@@ -147,6 +150,53 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
+    resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+    resolution: {integrity: sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260730.1':
+    resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+    resolution: {integrity: sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260730.1':
+    resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@docsearch/css@4.7.0':
     resolution: {integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==}
 
@@ -171,6 +221,162 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@hono/node-server@1.19.17':
     resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
@@ -183,6 +389,168 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -192,6 +560,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
@@ -618,6 +989,15 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -753,6 +1133,13 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.23':
+    resolution: {integrity: sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1366,6 +1753,9 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
@@ -1470,6 +1860,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1555,8 +1949,16 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1713,6 +2115,10 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
@@ -1825,6 +2231,10 @@ packages:
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  miniflare@5.20260730.0-alpha:
+    resolution: {integrity: sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==}
+    engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -1957,6 +2367,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -2057,6 +2470,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
+
   shiki@4.4.1:
     resolution: {integrity: sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==}
     engines: {node: '>=20'}
@@ -2090,6 +2507,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2155,6 +2576,13 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -2315,6 +2743,33 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260730.1:
+    resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.118.0:
+    resolution: {integrity: sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260730.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
@@ -2338,6 +2793,12 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   yuku-codegen@0.5.48:
     resolution: {integrity: sha512-p7HxD5Xl4jzDzqMrGePAOeSHmRY4g58h4HuGq15weQFPxuPWd/W6e7nqp/+Lea6JfpOdBwJOAyXFqIZ/J9Zfnw==}
@@ -2380,6 +2841,33 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260730.1
+
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260730.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260730.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@docsearch/css@4.7.0': {}
 
   '@docsearch/js@4.7.0': {}
@@ -2413,6 +2901,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@hono/node-server@1.19.17(hono@4.12.33)':
     dependencies:
       hono: 4.12.33
@@ -2423,11 +2989,122 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
+    optional: true
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2652,6 +3329,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -2751,6 +3440,10 @@ snapshots:
       '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.23': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2884,40 +3577,40 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-vue@6.0.8(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.8(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       vue: 3.5.40(typescript@7.0.2)
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.40(typescript@7.0.2)
 
-  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -2937,9 +3630,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2950,13 +3643,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2982,7 +3675,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.141.0
       '@oxc-project/types': 0.141.0
@@ -2992,6 +3685,7 @@ snapshots:
       yuku-parser: 0.5.48
     optionalDependencies:
       '@types/node': 25.9.5
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       typescript: 7.0.2
@@ -3210,6 +3904,8 @@ snapshots:
 
   birpc@2.9.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
@@ -3356,6 +4052,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   csstype@3.2.3: {}
 
   debug@2.6.9(supports-color@7.2.0):
@@ -3425,7 +4123,38 @@ snapshots:
 
   entities@7.0.1: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-module-lexer@2.3.1: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-html@1.0.3: {}
 
@@ -3588,6 +4317,8 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
+  kleur@4.1.5: {}
+
   lightningcss-android-arm64@1.33.0:
     optional: true
 
@@ -3685,6 +4416,18 @@ snapshots:
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  miniflare@5.20260730.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.28.0
+      workerd: 1.20260730.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@10.2.6:
     dependencies:
@@ -3789,7 +4532,7 @@ snapshots:
       '@oxc-minify/binding-win32-ia32-msvc': 0.142.0
       '@oxc-minify/binding-win32-x64-msvc': 0.142.0
 
-  oxfmt@0.60.0(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
+  oxfmt@0.60.0(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -3812,7 +4555,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.60.0
       '@oxfmt/binding-win32-ia32-msvc': 0.60.0
       '@oxfmt/binding-win32-x64-msvc': 0.60.0
-      vite-plus: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+      vite-plus: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -3823,7 +4566,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
+  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.75.0
       '@oxlint/binding-android-arm64': 1.75.0
@@ -3845,7 +4588,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.75.0
       '@oxlint/binding-win32-x64-msvc': 1.75.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+      vite-plus: 0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
 
   package-manager-detector@1.8.0: {}
 
@@ -3855,6 +4598,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
 
   pathe@1.1.2: {}
 
@@ -3963,6 +4708,38 @@ snapshots:
 
   semver@7.8.5: {}
 
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
+
   shiki@4.4.1:
     dependencies:
       '@shikijs/core': 4.4.1
@@ -3998,6 +4775,8 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -4080,6 +4859,12 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -4119,24 +4904,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0):
+  vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.141.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
-      oxfmt: 0.60.0(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
-      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-core': 0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)
+      oxfmt: 0.60.0(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.7(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
+      vitest: 4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1)
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.7
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.7
@@ -4177,7 +4962,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -4186,11 +4971,12 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.5
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@2.0.0-alpha.18(@types/node@25.9.5)(jiti@2.7.0)(postcss@8.5.25)(typescript@7.0.2)(yaml@2.9.0):
+  vitepress@2.0.0-alpha.18(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(postcss@8.5.25)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 4.7.0
       '@docsearch/js': 4.7.0
@@ -4200,7 +4986,7 @@ snapshots:
       '@shikijs/transformers': 4.4.1
       '@shikijs/types': 4.4.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@7.0.2))
       '@vue/devtools-api': 8.2.1
       '@vue/shared': 3.5.40
       '@vueuse/core': 14.4.0(vue@3.5.40(typescript@7.0.2))
@@ -4209,7 +4995,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 4.4.1
-      vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vue: 3.5.40(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.25
@@ -4239,10 +5025,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1):
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(happy-dom@20.11.1):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -4259,11 +5045,11 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)'
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.7(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       happy-dom: 20.11.1
     transitivePeerDependencies:
@@ -4286,6 +5072,32 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260730.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260730.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260730.1
+      '@cloudflare/workerd-linux-64': 1.20260730.1
+      '@cloudflare/workerd-linux-arm64': 1.20260730.1
+      '@cloudflare/workerd-windows-64': 1.20260730.1
+
+  wrangler@4.118.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260730.0-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260730.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.21.0: {}
+
   ws@8.21.1: {}
 
   wsl-utils@0.1.0:
@@ -4295,6 +5107,19 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.9.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.23
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   yuku-codegen@0.5.48:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,6 @@ peerDependencyRules:
   allowedVersions:
     vite: '*'
     vitest: '*'
+allowBuilds:
+  esbuild: true
+  workerd: true

--- a/src/build/generate.test.ts
+++ b/src/build/generate.test.ts
@@ -1,7 +1,27 @@
 import { describe, test, expect } from 'vite-plus/test'
 
 import { asAbs } from '../shared/path.ts'
-import { generateEntryTypesCode } from './generate.ts'
+import {
+  generateEntryTypesCode,
+  generateStaticRuntimeCode,
+  generateStaticRuntimeDeclarationCode,
+} from './generate.ts'
+
+describe('generateStaticRuntimeCode', () => {
+  test('statically imports the emitted server entry and manifest', () => {
+    const result = generateStaticRuntimeCode()
+
+    expect(result).toContain('import entries from "./server-entry.js"')
+    expect(result).toContain('import manifest from "./visle-manifest.json" with { type: "json" }')
+    expect(result).toContain('export default {\n  entries,\n  manifest,\n}')
+  })
+
+  test('generates a declaration for TypeScript consumers', () => {
+    expect(generateStaticRuntimeDeclarationCode()).toContain(
+      "import type { StaticRuntime } from 'visle'",
+    )
+  })
+})
 
 describe('generateEntryTypesCode', () => {
   test('generates module augmentation with component entries', () => {

--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -1,7 +1,12 @@
+import { manifestFileName } from '../shared/manifest.js'
 import { type AbsolutePath, type RelativePath, relative } from '../shared/path.js'
 import { stripEntryExt } from './paths.js'
 
 export const serverVirtualEntryId = '\0@visle/server-entry'
+
+export const serverEntryFileName = 'server-entry.js'
+export const runtimeFileName = 'visle-runtime.js'
+export const runtimeDeclarationFileName = 'visle-runtime.d.ts'
 
 export const componentWrapPrefix = '\0visle:wrap:'
 
@@ -20,6 +25,33 @@ export function generateServerVirtualEntryCode(
     .join(',\n')
 
   return `${imports}\nexport default {\n${entries}\n}`
+}
+
+/**
+ * Generate the production runtime module. The relative import is deliberately
+ * static so deployment bundlers can discover every server entry.
+ */
+export function generateStaticRuntimeCode(): string {
+  const importPath = `./${serverEntryFileName}`
+  const manifestImportPath = `./${manifestFileName}`
+
+  return `import entries from ${JSON.stringify(importPath)}
+import manifest from ${JSON.stringify(manifestImportPath)} with { type: "json" }
+
+export default {
+  entries,
+  manifest,
+}
+`
+}
+
+export function generateStaticRuntimeDeclarationCode(): string {
+  return `import type { StaticRuntime } from 'visle'
+
+declare const runtime: StaticRuntime
+
+export default runtime
+`
 }
 
 export function generateComponentWrapperCode(

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -6,7 +6,14 @@ import type { Plugin } from 'vite'
 import { type VisleConfig, defaultConfig, setVisleConfig } from '../shared/config.js'
 import { manifestFileName } from '../shared/manifest.js'
 import { asAbs, join, resolve } from '../shared/path.js'
-import { serverVirtualEntryId } from './generate.js'
+import {
+  generateStaticRuntimeCode,
+  generateStaticRuntimeDeclarationCode,
+  runtimeDeclarationFileName,
+  runtimeFileName,
+  serverEntryFileName,
+  serverVirtualEntryId,
+} from './generate.js'
 import { islandsBootstrapPath, resolveServerComponentIds } from './paths.js'
 import { devStyleSSRPlugin } from './plugins/dev-style-ssr.js'
 import { entryTypesPlugin } from './plugins/entry-types.js'
@@ -74,6 +81,9 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               outDir: resolvedConfig.serverOutDir,
               rollupOptions: {
                 input: [serverVirtualEntryId],
+                output: {
+                  entryFileNames: serverEntryFileName,
+                },
               },
             },
           },
@@ -100,6 +110,11 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               fs.writeFile(
                 join(serverOutDir, manifestFileName),
                 JSON.stringify(getManifestData(), null, 2),
+              ),
+              fs.writeFile(join(serverOutDir, runtimeFileName), generateStaticRuntimeCode()),
+              fs.writeFile(
+                join(serverOutDir, runtimeDeclarationFileName),
+                generateStaticRuntimeDeclarationCode(),
               ),
               generateEntryTypes(),
             ])

--- a/src/dev/index.test.ts
+++ b/src/dev/index.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
+
+import { visle } from '../build/index.ts'
+import { createRender } from '../server/render.ts'
+import { createDevLoader } from './index.ts'
+
+const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/dev')
+
+describe('createDevLoader', () => {
+  let root: string
+  let loader: ReturnType<typeof createDevLoader> | undefined
+
+  beforeEach(async () => {
+    await fs.mkdir(generatedDir, { recursive: true })
+    root = await fs.mkdtemp(path.join(generatedDir, 'render-'))
+  })
+
+  afterEach(async () => {
+    await loader?.close()
+    loader = undefined
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  test('renders a Vue component from the entry directory', async () => {
+    const render = createRender()
+    loader = createDevLoader({
+      root,
+      plugins: [visle()],
+      resolve: {
+        alias: {
+          'visle/internal': path.resolve(import.meta.dirname, '../server/internal.ts'),
+        },
+      },
+    })
+
+    render.setLoader(loader)
+
+    await fs.mkdir(path.join(root, 'src/pages'), { recursive: true })
+    await fs.writeFile(
+      path.join(root, 'src/pages/Comp.vue'),
+      '<template><div>Hello</div></template>',
+    )
+
+    await expect(render('Comp')).resolves.toBe('<div>Hello</div>')
+  })
+})

--- a/src/server/__tests__/runtime-boundary.test.ts
+++ b/src/server/__tests__/runtime-boundary.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, test } from 'vite-plus/test'
+
+const serverDir = path.resolve(import.meta.dirname, '..')
+
+/**
+ * Resolve specifier to actual file path. Return undefined if it is not a relative path.
+ */
+function resolveSource(importer: string, specifier: string): string | undefined {
+  if (!specifier.startsWith('.')) {
+    return undefined
+  }
+
+  const resolved = path.resolve(path.dirname(importer), specifier)
+  const candidates = [resolved.replace(/\.js$/, '.ts'), resolved, path.join(resolved, 'index.ts')]
+  return candidates.find((candidate) => fs.existsSync(candidate))
+}
+
+function collectImportGraph(entryPoints: string[]) {
+  const files = new Set<string>()
+  const externalImports = new Set<string>()
+  const pending = [...entryPoints]
+
+  while (pending.length > 0) {
+    const file = pending.pop()!
+    if (files.has(file)) {
+      continue
+    }
+    files.add(file)
+
+    const source = fs.readFileSync(file, 'utf-8')
+    const importPattern = /(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\sfrom\s*)?['"]([^'"]+)['"]/g
+
+    for (const match of source.matchAll(importPattern)) {
+      const specifier = match[1]!
+      const resolved = resolveSource(file, specifier)
+      if (resolved) {
+        pending.push(resolved)
+      } else {
+        externalImports.add(specifier)
+      }
+    }
+  }
+
+  return { files, externalImports }
+}
+
+describe('production runtime dependency boundary', () => {
+  test('root and internal entry points do not reach Node or development modules', () => {
+    const graph = collectImportGraph([
+      path.join(serverDir, 'index.ts'),
+      path.join(serverDir, 'internal.ts'),
+    ])
+
+    // Check if there is no forbidden dependencies for server runtime.
+    expect([...graph.externalImports].filter((id) => id.startsWith('node:'))).toEqual([])
+    expect(graph.externalImports).not.toContain('vite')
+    expect(graph.externalImports).not.toContain('connect')
+
+    // Check if there is no dependency to dev/build directories.
+    const sourceFiles = [...graph.files].map((file) => path.relative(path.dirname(serverDir), file))
+    expect(sourceFiles.some((file) => file.startsWith(`dev${path.sep}`))).toBe(false)
+    expect(sourceFiles.some((file) => file.startsWith(`build${path.sep}`))).toBe(false)
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,17 @@
 import type { AllowedComponentProps, ComponentCustomProps, VNodeProps } from 'vue'
 
 export { createRender } from './render.js'
+export { createStaticLoader } from './static-loader.js'
+export type { ManifestData } from '../shared/manifest.js'
+export type { RuntimeManifest } from './manifest.js'
+export type {
+  RenderArgs,
+  RenderContext,
+  RenderFunction,
+  RenderLoader,
+  RenderOptions,
+} from './render.js'
+export type { StaticRuntime } from './static-loader.js'
 
 export type ComponentProps<T> = T extends new (...args: any) => { $props: infer P }
   ? // ComponentCustomProps can have extra fields with declaration merging.

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -1,128 +1,84 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import { describe, expect, test } from 'vite-plus/test'
 
-import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
+import type { ManifestData } from '../shared/manifest.ts'
+import { createRuntimeManifest } from './manifest.ts'
 
-import { manifestFileName } from '../shared/manifest.ts'
-import { asAbs } from '../shared/path.ts'
-import { loadManifest } from './manifest.ts'
-
-const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/server')
-
-let root: string
-
-beforeEach(() => {
-  fs.mkdirSync(generatedDir, { recursive: true })
-  root = fs.mkdtempSync(path.join(generatedDir, 'manifest-'))
-})
-
-afterEach(() => {
-  fs.rmSync(root, { recursive: true, force: true })
-})
-
-describe('loadManifest', () => {
-  function writeManifest(data: {
-    base?: string
-    entryDir?: string
-    entryExt?: string[]
-    cssMap?: Record<string, string[]>
-    jsMap?: Record<string, string>
-  }): void {
-    fs.writeFileSync(
-      path.join(root, manifestFileName),
-      JSON.stringify({
-        base: '/',
-        entryDir: 'src/pages',
-        entryExt: ['.vue'],
-        cssMap: {},
-        jsMap: {},
-        ...data,
-      }),
-    )
+function createManifestData(data: Partial<ManifestData> = {}): ManifestData {
+  return {
+    base: '/',
+    entryDir: 'src/pages',
+    entryExt: ['.vue'],
+    cssMap: {},
+    jsMap: {},
+    islandsBootstrap: 'assets/islands.js',
+    ...data,
   }
+}
 
-  test('get file path derived from js map', async () => {
-    writeManifest({
-      jsMap: { 'src/foo.vue': 'foo-1234.js' },
-    })
+describe('createRuntimeManifest', () => {
+  test('gets a file path derived from the JS map', async () => {
+    const manifest = createRuntimeManifest(
+      createManifestData({ jsMap: { 'src/foo.vue': 'foo-1234.js' } }),
+    )
 
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getClientImportId('src/foo.vue')
-
-    expect(result).toBe('/foo-1234.js')
+    await expect(manifest.getClientImportId('src/foo.vue')).resolves.toBe('/foo-1234.js')
   })
 
-  test('throw error if js map does not include passed file path', async () => {
-    writeManifest({
-      jsMap: {},
-    })
-
-    const manifest = await loadManifest(asAbs(root))
+  test('throws if the JS map does not include the file path', async () => {
+    const manifest = createRuntimeManifest(createManifestData())
 
     await expect(manifest.getClientImportId('src/foo.vue')).rejects.toThrow(
       'src/foo.vue not found in manifest JS map',
     )
   })
 
-  test('get entry css ids from css map', async () => {
-    writeManifest({
-      cssMap: { 'src/pages/foo.vue': ['foo-1234.css'] },
-    })
-
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getEntryCssIds('foo')
-
-    expect(result).toEqual(['/foo-1234.css'])
-  })
-
   test.for([
     ['https://example.com/prefix', 'https://example.com/prefix/foo-1234.js'],
     ['/prefix', '/prefix/foo-1234.js'],
-  ] as const)('prepend base to file path: %s', async ([base, expected]) => {
-    writeManifest({
-      base,
-      jsMap: { 'src/foo.vue': 'foo-1234.js' },
-    })
+  ] as const)('prepends base to file path: %s', async ([base, expected]) => {
+    const manifest = createRuntimeManifest(
+      createManifestData({
+        base,
+        jsMap: { 'src/foo.vue': 'foo-1234.js' },
+      }),
+    )
 
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getClientImportId('src/foo.vue')
-
-    expect(result).toBe(expected)
+    await expect(manifest.getClientImportId('src/foo.vue')).resolves.toBe(expected)
   })
 
-  test('getEntryCssIds uses entryDir from manifest data', async () => {
-    writeManifest({
-      entryDir: 'views',
-      cssMap: { 'views/index.vue': ['index-1234.css'] },
-    })
+  test('uses the configured entry directory', async () => {
+    const manifest = createRuntimeManifest(
+      createManifestData({
+        entryDir: 'views',
+        cssMap: { 'views/index.vue': ['index-1234.css'] },
+      }),
+    )
 
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getEntryCssIds('index')
-
-    expect(result).toEqual(['/index-1234.css'])
+    await expect(manifest.getEntryCssIds('index')).resolves.toEqual(['/index-1234.css'])
   })
 
-  test('getEntryCssIds resolves custom entry extension', async () => {
-    writeManifest({
-      entryExt: ['.vue', '.md'],
-      cssMap: { 'src/pages/post.md': ['post-1234.css'] },
-    })
+  test('resolves custom entry extensions', async () => {
+    const manifest = createRuntimeManifest(
+      createManifestData({
+        entryExt: ['.vue', '.md'],
+        cssMap: { 'src/pages/post.md': ['post-1234.css'] },
+      }),
+    )
 
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getEntryCssIds('post')
-
-    expect(result).toEqual(['/post-1234.css'])
+    await expect(manifest.getEntryCssIds('post')).resolves.toEqual(['/post-1234.css'])
   })
 
-  test('getEntryCssIds returns empty array when no extension matches', async () => {
-    writeManifest({
-      entryExt: ['.vue'],
-      cssMap: {},
-    })
+  test('returns an empty CSS list when no extension matches', async () => {
+    const manifest = createRuntimeManifest(createManifestData())
 
-    const manifest = await loadManifest(asAbs(root))
-    const result = await manifest.getEntryCssIds('nonexistent')
+    await expect(manifest.getEntryCssIds('nonexistent')).resolves.toEqual([])
+  })
 
-    expect(result).toEqual([])
+  test('gets the islands bootstrap path', async () => {
+    const manifest = createRuntimeManifest(
+      createManifestData({ base: '/shop/', islandsBootstrap: 'assets/islands-1234.js' }),
+    )
+
+    await expect(manifest.getIslandsBootstrapId()).resolves.toBe('/shop/assets/islands-1234.js')
   })
 })

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -1,7 +1,4 @@
-import fs from 'node:fs/promises'
-
-import { manifestFileName, type ManifestData } from '../shared/manifest.js'
-import { type AbsolutePath, join } from '../shared/path.js'
+import type { ManifestData } from '../shared/manifest.js'
 
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
@@ -10,12 +7,9 @@ export interface RuntimeManifest {
 }
 
 /**
- * Loads the manifest file from serverOutDir for production SSR.
+ * Creates the platform-neutral runtime view of build manifest data.
  */
-export async function loadManifest(serverOutDir: AbsolutePath): Promise<RuntimeManifest> {
-  const manifestPath = join(serverOutDir, manifestFileName)
-
-  const data: ManifestData = JSON.parse(await fs.readFile(manifestPath, 'utf-8'))
+export function createRuntimeManifest(data: ManifestData): RuntimeManifest {
   const basePath = data.base.replace(/\/$/, '')
 
   return {

--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -1,196 +1,88 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vite-plus/test'
+import { defineComponent, h, type Component } from 'vue'
 
-import { afterEach, describe, test, expect, beforeEach } from 'vite-plus/test'
+import type { ManifestData } from '../shared/manifest.ts'
+import { createRender, type RenderLoader } from './render.ts'
+import { createStaticLoader } from './static-loader.ts'
 
-import { visle } from '../build/index.ts'
-import { createDevLoader } from '../dev/index.ts'
-import { createRender } from './render.ts'
+const emptyManifest: ManifestData = {
+  base: '/',
+  entryDir: 'src/pages',
+  entryExt: ['.vue'],
+  cssMap: {},
+  jsMap: {},
+  islandsBootstrap: 'assets/islands.js',
+}
 
-const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/server')
-
-/**
- * Save JavaScript code provided as the argument.
- *
- * @param root
- *   The root directory to save the codes.
- * @param codes
- *   JavaScript codes that will be saved.
- *   Keys are relative paths to be saved. Values are code strings.
- */
-async function saveCodes(root: string, codes: Record<string, string>): Promise<void> {
-  // Save each component code to a file
-  const promises = Object.entries(codes).map(async ([filePath, code]) => {
-    const fullPath = path.join(root, filePath)
-    const dirPath = path.dirname(fullPath)
-    await fs.mkdir(dirPath, { recursive: true })
-    await fs.writeFile(fullPath, code, 'utf8')
-  })
-
-  await Promise.all(promises)
+function loaderFor(component: Component): RenderLoader {
+  return createStaticLoader({ entries: { Comp: component }, manifest: emptyManifest })
 }
 
 describe('createRender', () => {
-  let root: string
+  test('throws a targeted error before a loader is configured', async () => {
+    const render = createRender()
 
-  beforeEach(async () => {
-    await fs.mkdir(generatedDir, { recursive: true })
-    root = await fs.mkdtemp(path.join(generatedDir, 'render-'))
+    await expect(render('Comp')).rejects.toThrow(
+      '[visle] Render loader is not configured. Call render.setLoader(loader) before rendering.',
+    )
   })
 
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true })
+  test('uses a loader passed during initialization', async () => {
+    const component = defineComponent({
+      props: { msg: { type: String, required: true } },
+      render() {
+        return h('div', this.msg)
+      },
+    })
+    const render = createRender({ loader: loaderFor(component) })
+
+    await expect(render('Comp', { msg: 'Hello' })).resolves.toBe('<div>Hello</div>')
   })
 
-  describe('isDev = false', () => {
-    const emptyManifest = JSON.stringify({
-      base: '/',
-      entryDir: 'src/pages',
-      cssMap: {},
-      jsMap: {},
-    })
+  test('setLoader enables rendering after shared initialization', async () => {
+    const render = createRender()
+    render.setLoader(
+      loaderFor(
+        defineComponent({
+          render: () => h('div', 'Hello'),
+        }),
+      ),
+    )
 
-    test('renders vue component with props', async () => {
-      const render = createRender({
-        serverOutDir: path.join(root, 'dist/server'),
-      })
-
-      await saveCodes(root, {
-        'dist/server/visle-manifest.json': emptyManifest,
-        'dist/server/server-entry.js': `
-          import { defineComponent, h } from 'vue'
-          export default { Comp: defineComponent({
-            props: {
-              msg: {
-                type: String,
-                required: true,
-              },
-            },
-            render() {
-              return h('div', {}, [this.msg])
-            },
-          }) }`,
-      })
-
-      const result = await render('Comp', { msg: 'Hello' })
-
-      expect(result).toBe('<div>Hello</div>')
-    })
-
-    test('renders vue component without props', async () => {
-      const render = createRender({
-        serverOutDir: path.join(root, 'dist/server'),
-      })
-
-      await saveCodes(root, {
-        'dist/server/visle-manifest.json': emptyManifest,
-        'dist/server/server-entry.js': `
-          import { defineComponent, h } from 'vue'
-          export default { Comp: defineComponent({
-            render() {
-              return h('div', {}, ['Hello'])
-            },
-          }) }`,
-      })
-
-      const result = await render('Comp')
-
-      expect(result).toBe('<div>Hello</div>')
-    })
-
-    test('renders vue component from .mjs file', async () => {
-      const render = createRender({
-        serverOutDir: path.join(root, 'dist/server'),
-      })
-
-      await saveCodes(root, {
-        'dist/server/visle-manifest.json': emptyManifest,
-        'dist/server/server-entry.mjs': `
-          import { defineComponent, h } from 'vue'
-          export default { Comp: defineComponent({
-            render() {
-              return h('div', {}, ['Hello'])
-            },
-          }) }`,
-      })
-
-      const result = await render('Comp')
-
-      expect(result).toBe('<div>Hello</div>')
-    })
-
-    test('renders head related tags', async () => {
-      const render = createRender({
-        serverOutDir: path.join(root, 'dist/server'),
-      })
-
-      await saveCodes(root, {
-        'dist/server/visle-manifest.json': emptyManifest,
-        'dist/server/server-entry.js': `
-          import { defineComponent, h } from 'vue'
-          export default { Comp: defineComponent({
-            render() {
-              return h('html', {}, [
-                h('head', {}, [
-                  h('title', {}, ['Hello']),
-                  h('meta', { charset: 'utf-8' }),
-                  h('link', { rel: 'stylesheet', href: 'style.css' }),
-                  h('style', {}, ['body { color: red; }']),
-                  h('script', { src: 'script.js' }),
-                  h('script', {}, ["console.log('Hello')"]),
-                ]),
-              ])
-            },
-          }) }`,
-      })
-
-      const result = await render('Comp')
-
-      expect(result).toBe(
-        '<html><head><title>Hello</title><meta charset="utf-8"><link rel="stylesheet" href="style.css"><style>body { color: red; }</style><script src="script.js"></script><script>console.log(&#39;Hello&#39;)</script></head></html>',
-      )
-    })
+    await expect(render('Comp')).resolves.toBe('<div>Hello</div>')
   })
 
-  describe('isDev = true', () => {
-    let loader: ReturnType<typeof createDevLoader> | undefined
-
-    afterEach(async () => {
-      await loader?.close()
-      loader = undefined
+  test('replaces the configured loader', async () => {
+    const render = createRender({
+      loader: loaderFor(defineComponent({ render: () => h('div', 'first') })),
     })
+    render.setLoader(loaderFor(defineComponent({ render: () => h('div', 'second') })))
 
-    test('renders vue component from component directory', async () => {
-      const render = createRender({
-        serverOutDir: path.join(root, 'dist/server'),
-      })
+    await expect(render('Comp')).resolves.toBe('<div>second</div>')
+  })
 
-      loader = createDevLoader({
-        root,
-        plugins: [visle()],
-        resolve: {
-          alias: {
-            'visle/internal': path.resolve(
-              path.dirname(fileURLToPath(import.meta.url)),
-              'internal.ts',
-            ),
+  test('renders head-related tags', async () => {
+    const render = createRender({
+      loader: loaderFor(
+        defineComponent({
+          render() {
+            return h('html', {}, [
+              h('head', {}, [
+                h('title', {}, ['Hello']),
+                h('meta', { charset: 'utf-8' }),
+                h('link', { rel: 'stylesheet', href: 'style.css' }),
+                h('style', {}, ['body { color: red; }']),
+                h('script', { src: 'script.js' }),
+                h('script', {}, ["console.log('Hello')"]),
+              ]),
+            ])
           },
-        },
-      })
-
-      render.setLoader(loader)
-
-      await saveCodes(root, {
-        'src/pages/Comp.vue': `
-          <template>
-            <div>Hello</div>
-          </template>`,
-      })
-
-      const result = await render('Comp')
-
-      expect(result).toBe('<div>Hello</div>')
+        }),
+      ),
     })
+
+    await expect(render('Comp')).resolves.toBe(
+      '<html><head><title>Hello</title><meta charset="utf-8"><link rel="stylesheet" href="style.css"><style>body { color: red; }</style><script src="script.js"></script><script>console.log(&#39;Hello&#39;)</script></head></html>',
+    )
   })
 })

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -1,20 +1,11 @@
-import path from 'node:path'
-
-import { Component, createApp } from 'vue'
+import { type Component, createApp } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
-import { defaultConfig } from '../shared/config.js'
-import { resolveServerDistPath } from '../shared/entry.js'
-import { asAbs } from '../shared/path.js'
-import { RuntimeManifest, loadManifest } from './manifest.js'
+import type { RuntimeManifest } from './manifest.js'
 import { transformWithRenderContext } from './transform.js'
 
 export interface RenderOptions {
-  /**
-   * Directory path for server build output.
-   * Pass the same value of Visle Vite plugin's serverOutDir.
-   */
-  serverOutDir?: string
+  loader?: RenderLoader
 }
 
 export interface RenderLoader {
@@ -27,9 +18,9 @@ export interface RenderContext {
   hasIsland?: boolean
 }
 
-type RenderArgs<P> = {} extends P ? [props?: P] : [props: P]
+export type RenderArgs<P> = {} extends P ? [props?: P] : [props: P]
 
-export interface RenderFunction<T extends Record<string, any> = Record<string, any>> {
+export interface RenderFunction<T extends Record<keyof T, unknown> = Record<string, unknown>> {
   <K extends string & keyof T>(componentPath: K, ...args: RenderArgs<T[K]>): Promise<string>
   setLoader(loader: RenderLoader): void
 }
@@ -37,37 +28,25 @@ export interface RenderFunction<T extends Record<string, any> = Record<string, a
 /**
  * Return a function that renders a Vue component to a HTML string.
  * The returned render function receives a path to a Vue component.
- * You need to specify Vite output directory of server build as same value as
- * defined in Vite config.
+ * A loader can be provided initially or installed later with `setLoader()`.
  */
-export function createRender<T extends Record<string, any> = Record<string, any>>(
+export function createRender<T extends Record<keyof T, unknown> = Record<string, unknown>>(
   options: RenderOptions = {},
 ): RenderFunction<T> {
-  let cachedManifest: RuntimeManifest | undefined
-
-  let loader: RenderLoader = {
-    loadEntry(componentPath) {
-      const serverOutDir = asAbs(path.resolve(options.serverOutDir ?? defaultConfig.serverOutDir))
-
-      return import(/* @vite-ignore */ resolveServerDistPath(serverOutDir)).then(
-        (m) => m.default[componentPath],
-      )
-    },
-
-    async getManifest() {
-      if (!cachedManifest) {
-        const serverOutDir = asAbs(path.resolve(options.serverOutDir ?? defaultConfig.serverOutDir))
-        cachedManifest = await loadManifest(serverOutDir)
-      }
-      return cachedManifest
-    },
-  }
+  let loader = options.loader
 
   async function render(componentPath: string, props?: any): Promise<string> {
-    const component = await loader.loadEntry(componentPath)
+    const activeLoader = loader
+    if (!activeLoader) {
+      throw new Error(
+        '[visle] Render loader is not configured. Call render.setLoader(loader) before rendering.',
+      )
+    }
+
+    const component = await activeLoader.loadEntry(componentPath)
 
     const context: RenderContext = {
-      manifest: await loader.getManifest(),
+      manifest: await activeLoader.getManifest(),
     }
 
     const app = createApp(component, props)

--- a/src/server/static-loader.test.ts
+++ b/src/server/static-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vite-plus/test'
+import { defineComponent } from 'vue'
+
+import type { ManifestData } from '../shared/manifest.ts'
+import { createStaticLoader } from './static-loader.ts'
+
+const manifest: ManifestData = {
+  base: '/',
+  entryDir: 'src/pages',
+  entryExt: ['.vue'],
+  cssMap: {},
+  jsMap: {},
+  islandsBootstrap: 'assets/islands.js',
+}
+
+describe('createStaticLoader', () => {
+  test('resolves known entries and reuses one runtime manifest', async () => {
+    const component = defineComponent({ template: '<div />' })
+    const loader = createStaticLoader({ entries: { index: component }, manifest })
+
+    await expect(loader.loadEntry('index')).resolves.toBe(component)
+    await expect(loader.getManifest()).resolves.toBe(await loader.getManifest())
+  })
+
+  test('rejects unknown entries with a descriptive error', async () => {
+    const loader = createStaticLoader({ entries: {}, manifest })
+
+    await expect(loader.loadEntry('missing')).rejects.toThrow(
+      '[visle] Unknown entry component: missing',
+    )
+  })
+})

--- a/src/server/static-loader.ts
+++ b/src/server/static-loader.ts
@@ -1,0 +1,30 @@
+import type { Component } from 'vue'
+
+import type { ManifestData } from '../shared/manifest.js'
+import { createRuntimeManifest } from './manifest.js'
+import type { RenderLoader } from './render.js'
+
+export interface StaticRuntime {
+  entries: Record<string, Component>
+  manifest: ManifestData
+}
+
+/**
+ * Creates a render loader backed entirely by statically imported build output.
+ */
+export function createStaticLoader(runtime: StaticRuntime): RenderLoader {
+  const manifest = createRuntimeManifest(runtime.manifest)
+
+  return {
+    async loadEntry(componentPath) {
+      if (!Object.hasOwn(runtime.entries, componentPath)) {
+        throw new Error(`[visle] Unknown entry component: ${componentPath}`)
+      }
+      return runtime.entries[componentPath]!
+    },
+
+    async getManifest() {
+      return manifest
+    },
+  }
+}

--- a/src/shared/entry.ts
+++ b/src/shared/entry.ts
@@ -1,21 +1,4 @@
-import fs from 'node:fs'
-
-import { type AbsolutePath, resolve } from './path.js'
-
 /**
  * Path to client bootstrap script that the browser request to.
  */
 export const virtualIslandsBootstrapPath = '/@visle/bootstrap'
-
-/**
- * Resolves the path to the server dist directory
- */
-export function resolveServerDistPath(serverOutDir: AbsolutePath): AbsolutePath {
-  const mjsPath = resolve(serverOutDir, 'server-entry.mjs')
-  const jsPath = resolve(serverOutDir, 'server-entry.js')
-
-  if (fs.existsSync(mjsPath)) {
-    return mjsPath
-  }
-  return jsPath
-}

--- a/test/hydration.test.ts
+++ b/test/hydration.test.ts
@@ -72,7 +72,7 @@ describe('Client-side Hydration', () => {
     await copyFixtures(root)
     await prodBuild(root)
 
-    const render = prodRender(root)
+    const render = await prodRender(root)
     const clientDir = path.join(root, 'dist/client')
 
     // Render each page and write as HTML files for the browser

--- a/test/prod.test.ts
+++ b/test/prod.test.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { describe, test, expect, beforeAll, afterAll } from 'vite-plus/test'
 
+import { runtimeFileName, serverEntryFileName } from '../src/build/generate.ts'
 import { RenderFunction } from '../src/server/render.ts'
 import { manifestFileName } from '../src/shared/manifest.ts'
 import {
@@ -24,7 +26,7 @@ describe('Production Build SSR', () => {
     root = await createTmpDir('prod')
     await copyFixtures(root)
     await prodBuild(root)
-    render = prodRender(root)
+    render = await prodRender(root)
   })
 
   afterAll(async () => {
@@ -78,7 +80,7 @@ describe('Production Build SSR with manual chunks', () => {
         },
       },
     })
-    render = prodRender(root)
+    render = await prodRender(root)
   })
 
   afterAll(async () => {
@@ -103,5 +105,55 @@ describe('Production Build SSR with manual chunks', () => {
     const result = await render('with-dynamic-shared-css')
 
     expect(normalizeHashes(result)).toMatchSnapshot()
+  })
+})
+
+describe('Production static runtime with custom server output', () => {
+  let root: string
+
+  beforeAll(async () => {
+    root = await createTmpDir('prod-static-runtime')
+    await fs.mkdir(path.join(root, 'pages'), { recursive: true })
+    await fs.writeFile(path.join(root, 'pages/index.vue'), '<template><div>Home</div></template>')
+
+    await prodBuild(
+      root,
+      {
+        base: '/shop/',
+        environments: {
+          server: {
+            build: {
+              rollupOptions: {
+                output: {
+                  entryFileNames: 'chunks/[name]-[hash].mjs',
+                },
+              },
+            },
+          },
+        },
+      },
+      { serverOutDir: 'custom/server' },
+    )
+  })
+
+  afterAll(async () => {
+    await removeTmpDir('prod-static-runtime')
+  })
+
+  test('imports the configured server entry and final manifest', async () => {
+    const serverDir = path.join(root, 'custom/server')
+    const runtimePath = path.join(serverDir, runtimeFileName)
+    const runtimeCode = await fs.readFile(runtimePath, 'utf-8')
+    const manifest = JSON.parse(await fs.readFile(path.join(serverDir, manifestFileName), 'utf-8'))
+
+    await expect(fs.access(path.join(serverDir, serverEntryFileName))).resolves.toBeUndefined()
+    expect(runtimeCode).toContain(`import entries from "./${serverEntryFileName}"`)
+    expect(runtimeCode).toContain(
+      `import manifest from "./${manifestFileName}" with { type: "json" }`,
+    )
+
+    const runtime = (await import(pathToFileURL(runtimePath).href)).default
+    expect(runtime.manifest).toEqual(manifest)
+    expect(Object.keys(runtime.entries)).toEqual(['index'])
   })
 })

--- a/test/prod.test.ts
+++ b/test/prod.test.ts
@@ -116,24 +116,7 @@ describe('Production static runtime with custom server output', () => {
     await fs.mkdir(path.join(root, 'pages'), { recursive: true })
     await fs.writeFile(path.join(root, 'pages/index.vue'), '<template><div>Home</div></template>')
 
-    await prodBuild(
-      root,
-      {
-        base: '/shop/',
-        environments: {
-          server: {
-            build: {
-              rollupOptions: {
-                output: {
-                  entryFileNames: 'chunks/[name]-[hash].mjs',
-                },
-              },
-            },
-          },
-        },
-      },
-      { serverOutDir: 'custom/server' },
-    )
+    await prodBuild(root, {}, { serverOutDir: 'custom/server' })
   })
 
   afterAll(async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { createBuilder, mergeConfig, type Plugin, type UserConfig } from 'vite'
 
-import { visle } from '../src/build/index.ts'
+import { visle, type VisleConfig } from '../src/build/index.ts'
 import { createDevLoader } from '../src/dev/index.ts'
 import { createRender } from '../src/server/render.ts'
+import { createStaticLoader, type StaticRuntime } from '../src/server/static-loader.ts'
 import { asRel } from '../src/shared/path.ts'
 
 const tmpDir = path.resolve('test/__generated__/integration')
@@ -136,7 +137,11 @@ export function devRender(root: string) {
 /**
  * Run a production Vite build with additional config options.
  */
-export async function prodBuild(root: string, options: UserConfig = {}): Promise<void> {
+export async function prodBuild(
+  root: string,
+  options: UserConfig = {},
+  visleConfig: VisleConfig = {},
+): Promise<void> {
   const builder = await createBuilder(
     mergeConfig(
       {
@@ -148,6 +153,7 @@ export async function prodBuild(root: string, options: UserConfig = {}): Promise
             entryExt,
             dts: 'visle-generated.d.ts',
             vue: { include: vueInclude },
+            ...visleConfig,
           }),
         ],
         resolve: {
@@ -168,10 +174,13 @@ export async function prodBuild(root: string, options: UserConfig = {}): Promise
 /**
  * Create a prod mode render function (after prodBuild).
  */
-export function prodRender(root: string) {
-  return createRender({
-    serverOutDir: path.join(root, 'dist/server'),
-  })
+export async function prodRender(root: string) {
+  const runtimePath = path.join(root, 'dist/server/visle-runtime.js')
+  const runtimeModule: {
+    default: StaticRuntime
+  } = await import(pathToFileURL(runtimePath).href)
+
+  return createRender({ loader: createStaticLoader(runtimeModule.default) })
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "include": [],
-  "references": [{ "path": "tsconfig.lib.json" }, { "path": "tsconfig.test.json" }]
+  "references": [
+    { "path": "tsconfig.lib.json" },
+    { "path": "tsconfig.runtime.json" },
+    { "path": "tsconfig.test.json" }
+  ]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -8,5 +8,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "**/__tests__/**/*.ts"]
 }

--- a/tsconfig.runtime.json
+++ b/tsconfig.runtime.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/server/index.ts", "src/server/internal.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src/**/*.test.ts", "test/**/*"]
+  "include": ["src/**/*.test.ts", "**/__tests__/**/*.ts", "test/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
       suspicious: 'error',
       perf: 'error',
     },
-    ignorePatterns: ['dist/', 'node_modules/'],
     options: {
       typeAware: true,
       typeCheck: true,


### PR DESCRIPTION
Added `createStaticLoader` for renderer loader. The user has to explicitly import build runtime code and specify the static loader in production code after merging this PR.

```ts
import { createRender, createStaticLoader } from 'visle'
import runtime from './dist/server/visle-runtime.js'

const render = createRender({
  loader: createStaticLoader(runtime)
})
```

With this change, Visle's server runtime no longer has Node.js dependency that allows to run it on non-Node.js runtime such as Cloudflare Workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static runtime loading for production rendering.
  * Production builds now generate runtime files and declarations for server-side rendering.
  * Added Cloudflare Worker deployment and local development support for the example app.

* **Documentation**
  * Updated API, development, production, and setup guides with static-loader configuration.

* **Tests**
  * Expanded coverage for static loading, runtime generation, rendering, hydration, and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->