### PR TITLE
refactor: extract all islands during style env build

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -17,6 +17,7 @@ import {
 import { islandsBootstrapPath, resolveServerComponentIds } from './paths.js'
 import { devStyleSSRPlugin } from './plugins/dev-style-ssr.js'
 import { entryTypesPlugin } from './plugins/entry-types.js'
+import { islandComponentsPlugin } from './plugins/island-components.js'
 import { manifestPlugin } from './plugins/manifest.js'
 import { serverTransformPlugin } from './plugins/server-transform.js'
 import { virtualFilePlugin } from './plugins/virtual-file.js'
@@ -26,7 +27,7 @@ export type { VisleConfig }
 
 /**
  * Visle plugin for Vite.
- * Configures style, islands, and server build environments,
+ * Configures style, client, and server build environments,
  * orchestrates the build order, and sets up Vue SFC compilation
  * with island component support.
  */
@@ -36,7 +37,8 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     ...config,
   }
 
-  const { plugin: serverTransform, islandPaths } = serverTransformPlugin(resolvedConfig.entryExt)
+  const { plugin: islandComponents, islandPaths } = islandComponentsPlugin(resolvedConfig.entryExt)
+  const serverTransform = serverTransformPlugin(resolvedConfig.entryExt)
   const virtualFile = virtualFilePlugin(resolvedConfig)
   const { plugin: manifest, getManifestData } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
@@ -62,14 +64,14 @@ export function visle(config: VisleConfig = {}): Plugin[] {
               },
             },
           },
-          islands: {
+          client: {
             consumer: 'client',
             build: {
               outDir: resolvedConfig.clientOutDir,
               emptyOutDir: false,
               rollupOptions: {
                 // Start with islands bootstrap;
-                // v-client island paths are added after server build
+                // v-client island paths are added after the style build
                 input: [islandsBootstrapPath],
                 preserveEntrySignatures: 'allow-extension',
               },
@@ -91,16 +93,11 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
         builder: {
           buildApp: async (builder) => {
-            // Build style and server in parallel
-            // - Style build produces cssMap (component -> CSS file mappings)
-            // - Server build discovers island component paths via server-transform rewriting
-            await Promise.all([
-              builder.build(builder.environments.style!),
-              builder.build(builder.environments.server!),
-            ])
-
-            // Build islands using entry paths collected during server build
-            await builder.build(builder.environments.islands!)
+            // The style traversal discovers every island component before the
+            // client environment consumes those paths as build inputs.
+            await builder.build(builder.environments.style!)
+            await builder.build(builder.environments.client!)
+            await builder.build(builder.environments.server!)
 
             // Write manifest and type definition files after all builds
             const serverOutDir = resolve(root, resolvedConfig.serverOutDir)
@@ -128,11 +125,11 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     },
   }
 
-  const islandsInputPlugin: Plugin = {
-    name: 'visle:islands-input',
+  const clientInputPlugin: Plugin = {
+    name: 'visle:client-input',
     sharedDuringBuild: true,
 
-    applyToEnvironment: (env) => env.name === 'islands',
+    applyToEnvironment: (env) => env.name === 'client',
 
     options(opts) {
       if (islandPaths.size === 0) {
@@ -141,11 +138,11 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
       if (!Array.isArray(opts.input) && typeof opts.input !== 'string') {
         this.error(
-          'It is not allowed to pass an object value to the input option of the islands environment',
+          'It is not allowed to pass an object value to the input option of the client environment',
         )
       }
 
-      // Update islands environment input with paths discovered during server build
+      // Update client environment input with paths discovered during style build
       const existing = Array.isArray(opts.input) ? opts.input : [opts.input]
 
       return { ...opts, input: [...existing, ...islandPaths] }
@@ -154,7 +151,8 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
   return [
     orchestrationPlugin,
-    islandsInputPlugin,
+    clientInputPlugin,
+    islandComponents,
     serverTransform,
     virtualFile,
     manifest,

--- a/src/build/plugins/island-components.ts
+++ b/src/build/plugins/island-components.ts
@@ -1,0 +1,53 @@
+import type { Plugin } from 'vite'
+
+import { hasEntryExt, parseId } from '../paths.js'
+import { extractIslandComponents } from '../sfc-analysis.js'
+
+interface IslandComponentsPluginResult {
+  plugin: Plugin
+  islandPaths: Set<string>
+}
+
+/**
+ * Collects island component paths while the style environment traverses every
+ * server entry and its dependencies.
+ */
+export function islandComponentsPlugin(entryExt: string[]): IslandComponentsPluginResult {
+  const islandPaths = new Set<string>()
+
+  const plugin: Plugin = {
+    name: 'visle:island-components',
+    enforce: 'pre',
+    sharedDuringBuild: true,
+
+    applyToEnvironment(environment) {
+      return environment.name === 'style'
+    },
+
+    buildStart() {
+      islandPaths.clear()
+    },
+
+    async transform(code, id) {
+      const { fileName, query } = parseId(id)
+
+      if (!hasEntryExt(fileName, entryExt) || query.vue) {
+        return null
+      }
+
+      const islands = await extractIslandComponents(id, code, async (source, importer) => {
+        return (await this.resolve(source, importer))?.id ?? null
+      })
+
+      for (const { resolvedPath } of islands) {
+        if (resolvedPath) {
+          islandPaths.add(resolvedPath)
+        }
+      }
+
+      return null
+    },
+  }
+
+  return { plugin, islandPaths }
+}

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -93,12 +93,12 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
         return
       }
 
-      if (envName === 'islands') {
+      if (envName === 'client') {
         const envJsMap = new Map<string, string>()
 
         for (const [key, chunk] of Object.entries(bundle)) {
           // Since we generate all style files in style environment,
-          // delete all css assets in islands environment
+          // delete all css assets in client environment
           if (
             chunk.type === 'asset' &&
             typeof chunk.fileName === 'string' &&

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -1,25 +1,17 @@
 import type { Plugin, ResolvedConfig } from 'vite'
-import { parse } from 'vue/compiler-sfc'
 
 import { asAbs, relative } from '../../shared/path.js'
 import { generateComponentWrapperCode, componentWrapPrefix } from '../generate.js'
 import { hasEntryExt, parseId } from '../paths.js'
-import { buildImportMap, findVClientElements } from '../sfc-analysis.js'
-
-interface ServerTransformPluginResult {
-  plugin: Plugin
-  islandPaths: Set<string>
-}
+import { extractIslandComponents } from '../sfc-analysis.js'
 
 /**
  * Vite plugin that transforms Vue SFC imports on the server environment.
  * - Redirects island component imports to component wrapper virtual modules
  * - Loads wrapper virtual modules with generated code
- * - Detects `v-client:load` directives and collects island component paths for the islands build
+ * - Detects `v-client:*` directives and records imports that need wrapping
  */
-export function serverTransformPlugin(entryExt: string[]): ServerTransformPluginResult {
-  const islandPaths = new Set<string>()
-
+export function serverTransformPlugin(entryExt: string[]): Plugin {
   /**
    * Map from importer file path → Map<resolvedSourcePath, Set<importedName>>
    * Tracks which imports need wrapping.
@@ -29,13 +21,13 @@ export function serverTransformPlugin(entryExt: string[]): ServerTransformPlugin
 
   let viteConfig: ResolvedConfig
 
-  const plugin: Plugin = {
+  return {
     name: 'visle:server-transform',
     enforce: 'pre',
     sharedDuringBuild: true,
 
     applyToEnvironment(environment) {
-      return environment.name === 'server'
+      return environment.config.consumer === 'server'
     },
 
     configResolved(resolvedConfig) {
@@ -43,7 +35,6 @@ export function serverTransformPlugin(entryExt: string[]): ServerTransformPlugin
     },
 
     buildStart() {
-      islandPaths.clear()
       componentNameMap.clear()
     },
 
@@ -109,49 +100,14 @@ export function serverTransformPlugin(entryExt: string[]): ServerTransformPlugin
         return null
       }
 
-      const { descriptor } = parse(code)
+      const islands = extractIslandComponents(id, code, async (source, importer) => {
+        // Note: skipSelf only works when this.resolve is called from resolveId.
+        // From transform, our resolveId still runs and wraps the result with a
+        // virtual module prefix, so we need to unwrap it.
+        return (await this.resolve(source, importer))?.id ?? null
+      })
 
-      if (!descriptor.template?.ast) {
-        return null
-      }
-
-      // Build tag-name-to-import-source map from <script> block
-      const importMap = buildImportMap(descriptor, id)
-
-      // Find elements with v-client:load
-      const matches = findVClientElements(descriptor.template.ast.children)
-
-      if (matches.length === 0) {
-        return null
-      }
-
-      // Resolve alias import sources in parallel
-      const resolveResults = await Promise.all(
-        matches.map(async (node) => {
-          const importInfo = importMap.get(node.tag)
-          if (!importInfo) {
-            return {
-              tag: node.tag,
-              importInfo: undefined,
-              resolvedPath: undefined,
-            }
-          }
-
-          // Note: skipSelf only works when this.resolve is called from resolveId.
-          // From transform, our resolveId still runs and wraps the result with a
-          // virtual module prefix, so we need to unwrap it.
-          const resolved = await this.resolve(importInfo.source, id)
-          const resolvedPath = resolved ? parseId(resolved.id).fileName : undefined
-
-          return {
-            tag: node.tag,
-            importInfo,
-            resolvedPath,
-          }
-        }),
-      )
-
-      for (const { tag, importInfo, resolvedPath } of resolveResults) {
+      for (const { tag, importInfo, resolvedPath } of await islands) {
         if (!importInfo) {
           this.warn(
             `v-client:load on "${tag}" is not supported. ` +
@@ -166,8 +122,6 @@ export function serverTransformPlugin(entryExt: string[]): ServerTransformPlugin
           )
           continue
         }
-
-        islandPaths.add(resolvedPath)
 
         // Record import name so resolveId can include it in the names query
         let nameMap = componentNameMap.get(fileName)
@@ -186,6 +140,4 @@ export function serverTransformPlugin(entryExt: string[]): ServerTransformPlugin
       return null
     },
   }
-
-  return { plugin, islandPaths }
 }

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -8,7 +8,7 @@ import { islandsBootstrapPath, resolveServerComponentIds } from '../paths.js'
 
 /**
  * Vite plugin that resolves and loads virtual entry modules
- * per environment (style, islands, server, dev client).
+ * per environment (style, client, server).
  */
 export function virtualFilePlugin(config: ResolvedVisleConfig): Plugin {
   let entryRoot: AbsolutePath

--- a/src/build/sfc-analysis.test.ts
+++ b/src/build/sfc-analysis.test.ts
@@ -1,11 +1,96 @@
 import { describe, test, expect } from 'vite-plus/test'
 import { parse } from 'vue/compiler-sfc'
 
-import { buildImportMap, findVClientElements } from './sfc-analysis.ts'
+import { buildImportMap, extractIslandComponents, findVClientElements } from './sfc-analysis.ts'
 
 function parseSfc(code: string) {
   return parse(code).descriptor
 }
+
+describe('extractIslandComponents', () => {
+  test('returns no islands when the component has no template', async () => {
+    const islands = await extractIslandComponents(
+      '/src/component.vue',
+      '<script setup>const message = "hello"</script>',
+      async () => '/unused.vue',
+    )
+
+    expect(islands).toEqual([])
+  })
+
+  test('returns no islands when the template has no v-client components', async () => {
+    const islands = await extractIslandComponents(
+      '/src/component.vue',
+      '<template><main>Static</main></template>',
+      async () => '/unused.vue',
+    )
+
+    expect(islands).toEqual([])
+  })
+
+  test('integrates component analysis with import resolution', async () => {
+    const id = '/src/pages/index.vue'
+    const resolveCalls: [source: string, importer: string][] = []
+    const code = `
+      <script setup>
+      import Counter from '../components/Counter.vue'
+      </script>
+      <template>
+        <main><Counter v-client:visible /></main>
+      </template>
+    `
+
+    const islands = await extractIslandComponents(id, code, async (source, importer) => {
+      resolveCalls.push([source, importer])
+      return '/src/components/Counter.vue?names=default'
+    })
+
+    expect(resolveCalls).toEqual([['../components/Counter.vue', id]])
+    expect(islands).toEqual([
+      {
+        tag: 'Counter',
+        importInfo: {
+          source: '../components/Counter.vue',
+          importedName: 'default',
+        },
+        resolvedPath: '/src/components/Counter.vue',
+      },
+    ])
+  })
+
+  test('preserves island metadata when imports are missing or unresolved', async () => {
+    const id = '/src/page.vue'
+    const resolveCalls: [source: string, importer: string][] = []
+    const code = `
+      <script setup>
+      import Counter from './Counter.vue'
+      </script>
+      <template>
+        <Counter v-client:load />
+        <Unregistered v-client:idle />
+      </template>
+    `
+
+    const islands = await extractIslandComponents(id, code, async (source, importer) => {
+      resolveCalls.push([source, importer])
+      return null
+    })
+
+    expect(resolveCalls).toEqual([['./Counter.vue', id]])
+    expect(islands).toEqual([
+      {
+        tag: 'Counter',
+        importInfo: { source: './Counter.vue', importedName: 'default' },
+        resolvedPath: undefined,
+      },
+      {
+        tag: 'Unregistered',
+        importInfo: undefined,
+        resolvedPath: undefined,
+      },
+    ])
+  })
+})
 
 describe('buildImportMap', () => {
   describe('script setup', () => {

--- a/src/build/sfc-analysis.ts
+++ b/src/build/sfc-analysis.ts
@@ -1,7 +1,68 @@
 import type { ObjectExpression } from '@babel/types'
 import type { ElementNode, TemplateChildNode } from '@vue/compiler-core'
 import { NodeTypes } from '@vue/compiler-core'
-import { compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
+import { parse, compileScript, type SFCDescriptor } from 'vue/compiler-sfc'
+
+import { parseId } from './paths.js'
+
+export interface IslandComponentInfo {
+  tag: string
+  importInfo?: ImportInfo
+  resolvedPath?: string
+}
+
+/**
+ * Extract all island components in the specified component code.
+ *
+ * @param id Extraction target component ID
+ * @param code Extraction target component code
+ * @param resolveId ID resolver function receiving resolving import source and importer ID
+ * @returns An array of resolved island components info
+ */
+export async function extractIslandComponents(
+  id: string,
+  code: string,
+  resolveId: (source: string, importer: string) => Promise<string | null>,
+): Promise<IslandComponentInfo[]> {
+  const { descriptor } = parse(code)
+
+  if (!descriptor.template?.ast) {
+    return []
+  }
+
+  // Build tag-name-to-import-source map from <script> block
+  const importMap = buildImportMap(descriptor, id)
+
+  // Find elements with v-client:load
+  const matches = findVClientElements(descriptor.template.ast.children)
+
+  if (matches.length === 0) {
+    return []
+  }
+
+  // Resolve alias import sources in parallel
+  return await Promise.all(
+    matches.map(async (node) => {
+      const importInfo = importMap.get(node.tag)
+      if (!importInfo) {
+        return {
+          tag: node.tag,
+          importInfo: undefined,
+          resolvedPath: undefined,
+        }
+      }
+
+      const resolvedId = await resolveId(importInfo.source, id)
+      const resolvedPath = resolvedId ? parseId(resolvedId).fileName : undefined
+
+      return {
+        tag: node.tag,
+        importInfo,
+        resolvedPath,
+      }
+    }),
+  )
+}
 
 export interface ImportInfo {
   source: string


### PR DESCRIPTION
Currently, Visle analyzes island components during server build and use that info in the later islands build. It introduces complicated dependencies between build envs because server build actually needs islands build info to resolve client asset paths for rendering. 

The current workaround for it is to write manifest file after islands build while letting the user import the output runtime JS which includes manifest data.

This workaround will not work when we want to build entire server code rather than building only components since we have to resolve the manifest data during server build.

In this PR, I have moved the island analysis into style env to be able to implement the above usage in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved island component discovery and processing during builds.
  * Builds now run in a consistent style, client, and server sequence.
  * Improved handling of client-side assets and generated manifests.

* **Bug Fixes**
  * Improved detection and resolution of client-rendered components.
  * Added handling for missing, unresolved, or incomplete component imports.

* **Tests**
  * Added coverage for island component extraction across multiple template and import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->