### PR TITLE
fix(hmr): inject vite client for hmr

### DIFF
--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -1,4 +1,4 @@
-import { virtualIslandsBootstrapPath } from '../shared/entry.js'
+import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
 import { manifestFileName } from '../shared/manifest.js'
 import type { BuildManifest } from '../shared/manifest.js'
 import { type AbsolutePath, type RelativePath, relative } from '../shared/path.js'
@@ -104,6 +104,7 @@ ${cssMap}
   },
   jsMap,
   islandsBootstrap: ${JSON.stringify(virtualIslandsBootstrapPath)},
+  devClient: ${JSON.stringify(viteDevClientPath)},
 }
 `
 }

--- a/src/dev/index.test.ts
+++ b/src/dev/index.test.ts
@@ -44,6 +44,8 @@ describe('createDevLoader', () => {
       '<template><div>Hello</div></template>',
     )
 
-    await expect(render('Comp')).resolves.toBe('<div>Hello</div>')
+    await expect(render('Comp')).resolves.toBe(
+      '<script type="module" src="/@vite/client" async></script><div>Hello</div>',
+    )
   })
 })

--- a/src/dev/manifest.test.ts
+++ b/src/dev/manifest.test.ts
@@ -5,7 +5,7 @@ import { createServer, type ViteDevServer } from 'vite'
 import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
 import { visle } from '../build/index.ts'
-import { virtualIslandsBootstrapPath } from '../shared/entry.ts'
+import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.ts'
 import { createDevManifest } from './manifest.ts'
 
 const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/dev')
@@ -53,10 +53,19 @@ describe('createDevManifest', () => {
     fs.writeFileSync(filePath, '<template><div /></template>\n<style>.page { color: red }</style>')
   }
 
-  test('returns the virtual islands bootstrap path', async () => {
+  test('returns the Vite development client without the islands bootstrap', async () => {
     const manifest = createDevManifest(await createTestServer())
 
-    await expect(manifest.getIslandsBootstrapId()).resolves.toBe(virtualIslandsBootstrapPath)
+    await expect(manifest.getBootstrapJsIds(false)).resolves.toEqual([viteDevClientPath])
+  })
+
+  test('returns the Vite development client and islands bootstrap for an island page', async () => {
+    const manifest = createDevManifest(await createTestServer())
+
+    await expect(manifest.getBootstrapJsIds(true)).resolves.toEqual([
+      viteDevClientPath,
+      virtualIslandsBootstrapPath,
+    ])
   })
 
   test('returns source paths for client imports', async () => {
@@ -95,6 +104,19 @@ describe('createDevManifest', () => {
 
     await expect(manifest.getEntryCssIds('foo')).resolves.toEqual([
       'http://localhost:3000/src/pages/foo.vue?vue&type=style&index=0&lang.css',
+    ])
+  })
+
+  test('applies the configured base and origin to the Vite development client', async () => {
+    const manifest = createDevManifest(
+      await createTestServer({
+        base: '/prefix/',
+        serverOrigin: 'http://localhost:3000',
+      }),
+    )
+
+    await expect(manifest.getBootstrapJsIds(false)).resolves.toEqual([
+      'http://localhost:3000/prefix/@vite/client',
     ])
   })
 })

--- a/src/dev/manifest.ts
+++ b/src/dev/manifest.ts
@@ -1,7 +1,7 @@
 import type { ViteDevServer } from 'vite'
 
 import type { RuntimeManifest } from '../server/manifest.js'
-import { virtualIslandsBootstrapPath } from '../shared/entry.js'
+import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
 import { getServerEnvironment } from './index.js'
 import { collectDevEntryCssIds } from './style.js'
 
@@ -22,8 +22,12 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
       return applyServeBase(`/${componentRelativePath}`)
     },
 
-    async getIslandsBootstrapId(): Promise<string> {
-      return applyServeBase(virtualIslandsBootstrapPath)
+    async getBootstrapJsIds(hasIsland: boolean): Promise<string[]> {
+      const ids = [applyServeBase(viteDevClientPath)]
+      if (hasIsland) {
+        ids.push(applyServeBase(virtualIslandsBootstrapPath))
+      }
+      return ids
     },
 
     async getEntryCssIds(componentPath: string): Promise<string[]> {

--- a/src/server/manifest.test.ts
+++ b/src/server/manifest.test.ts
@@ -94,11 +94,31 @@ describe('createRuntimeManifest', () => {
     await expect(manifest.getEntryCssIds('nonexistent')).resolves.toEqual([])
   })
 
-  test('gets the islands bootstrap path', async () => {
+  test('gets no bootstrap JavaScript for a production page without islands', async () => {
+    const manifest = createRuntimeManifest(createManifestSource())
+
+    await expect(manifest.getBootstrapJsIds(false)).resolves.toEqual([])
+  })
+
+  test('gets the islands bootstrap path for a production page with islands', async () => {
     const manifest = createRuntimeManifest(
       createManifestSource({ base: '/shop/', islandsBootstrap: 'assets/islands-1234.js' }),
     )
 
-    await expect(manifest.getIslandsBootstrapId()).resolves.toBe('/shop/assets/islands-1234.js')
+    await expect(manifest.getBootstrapJsIds(true)).resolves.toEqual([
+      '/shop/assets/islands-1234.js',
+    ])
+  })
+
+  test('gets development and island bootstrap paths when configured', async () => {
+    const manifest = createRuntimeManifest(
+      createManifestSource({ base: '/shop/', devClient: '/@vite/client' }),
+    )
+
+    await expect(manifest.getBootstrapJsIds(false)).resolves.toEqual(['/shop/@vite/client'])
+    await expect(manifest.getBootstrapJsIds(true)).resolves.toEqual([
+      '/shop/@vite/client',
+      '/shop/assets/islands.js',
+    ])
   })
 })

--- a/src/server/manifest.ts
+++ b/src/server/manifest.ts
@@ -3,7 +3,7 @@ import type { ManifestSource, SourceValue } from '../shared/manifest.js'
 export interface RuntimeManifest {
   getClientImportId(componentRelativePath: string): Promise<string>
   getEntryCssIds(componentPath: string): Promise<string[]>
-  getIslandsBootstrapId(): Promise<string>
+  getBootstrapJsIds(hasIsland: boolean): Promise<string[]>
 }
 
 function resolveSourceValue(source: SourceValue<string>): Promise<string>
@@ -46,8 +46,12 @@ export function createRuntimeManifest(source: ManifestSource): RuntimeManifest {
       return cssIds.map(resolveAssetId)
     },
 
-    async getIslandsBootstrapId(): Promise<string> {
-      return resolveAssetId(source.islandsBootstrap)
+    async getBootstrapJsIds(hasIsland: boolean): Promise<string[]> {
+      const ids = source.devClient ? [resolveAssetId(source.devClient)] : []
+      if (hasIsland) {
+        ids.push(resolveAssetId(source.islandsBootstrap))
+      }
+      return ids
     },
   }
 }

--- a/src/server/render.test.ts
+++ b/src/server/render.test.ts
@@ -61,6 +61,19 @@ describe('createRender', () => {
     await expect(render('Comp')).resolves.toBe('<div>second</div>')
   })
 
+  test('injects a configured development client without an island', async () => {
+    const render = createRender({
+      loader: createBundleLoader({
+        entries: { Comp: () => defineComponent({ render: () => h('div', 'Hello') }) },
+        manifest: { ...emptyManifest, devClient: '/@vite/client' },
+      }),
+    })
+
+    await expect(render('Comp')).resolves.toBe(
+      '<script type="module" src="/@vite/client" async></script><div>Hello</div>',
+    )
+  })
+
   test('renders head-related tags', async () => {
     const render = createRender({
       loader: loaderFor(

--- a/src/server/render.ts
+++ b/src/server/render.ts
@@ -57,11 +57,7 @@ export function createRender<T extends Record<keyof T, unknown> = Record<string,
     // Collect CSS for the page entry after rendering so module graph is populated
     const css = await manifest.getEntryCssIds(componentPath)
 
-    // Collect JS for islands bootstrap if any island component was rendered
-    const js: string[] = []
-    if (context.hasIsland) {
-      js.push(await manifest.getIslandsBootstrapId())
-    }
+    const js = await manifest.getBootstrapJsIds(context.hasIsland ?? false)
 
     return transformWithRenderContext(rendered, { css, js })
   }

--- a/src/shared/entry.ts
+++ b/src/shared/entry.ts
@@ -2,3 +2,8 @@
  * Path to client bootstrap script that the browser request to.
  */
 export const virtualIslandsBootstrapPath = '/@visle/bootstrap'
+
+/**
+ * Path to Vite's development client.
+ */
+export const viteDevClientPath = '/@vite/client'

--- a/src/shared/manifest.ts
+++ b/src/shared/manifest.ts
@@ -9,6 +9,7 @@ interface ManifestShape<CssValue, JsValue> {
   cssMap: Record<string, CssValue>
   jsMap: Record<string, JsValue>
   islandsBootstrap: string
+  devClient?: string
 }
 
 export type BuildManifest = ManifestShape<string[], string>

--- a/test/__snapshots__/dev.test.ts.snap
+++ b/test/__snapshots__/dev.test.ts.snap
@@ -5,6 +5,12 @@ exports[`Dev Server SSR > 'CSS import in script' 1`] = `
   rel="stylesheet"
   href="/styles/imported.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div>
   <h2>
     CSS Import Page
@@ -17,6 +23,12 @@ exports[`Dev Server SSR > 'CSS modules' 1`] = `
   rel="stylesheet"
   href="/pages/with-css-module.vue?vue&type=style&index=0&lang.module.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div class="_container_[css-module-hash]">
   CSS Module
 </div>
@@ -31,6 +43,12 @@ exports[`Dev Server SSR > 'CSS with style src alias' 1`] = `
   rel="stylesheet"
   href="/styles/alias-counter.css?vue&type=style&index=0&src=[src]&scoped=[scoped]&lang.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -60,6 +78,12 @@ exports[`Dev Server SSR > 'CSS with style src' 1`] = `
 >
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -77,6 +101,12 @@ exports[`Dev Server SSR > 'CSS with style src' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Component in subdirectory' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div>
   Subdirectory Page
 </div>
@@ -91,6 +121,12 @@ exports[`Dev Server SSR > 'Component with CSS' 1`] = `
   rel="stylesheet"
   href="/components/StyledCounter.vue?vue&type=style&index=0&scoped=[scoped]&lang.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -112,6 +148,12 @@ exports[`Dev Server SSR > 'Component with CSS' 1`] = `
 exports[`Dev Server SSR > 'Component with island' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -129,6 +171,12 @@ exports[`Dev Server SSR > 'Component with island' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Component with props' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div>
   Hello Props
 </div>
@@ -143,6 +191,12 @@ exports[`Dev Server SSR > 'Dynamic import shared CSS' 1`] = `
   rel="stylesheet"
   href="/components/StyledCounter.vue?vue&type=style&index=0&scoped=[scoped]&lang.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -173,6 +227,12 @@ exports[`Dev Server SSR > 'Full HTML document with head/body' 1`] = `
     </title>
     <script
       type="module"
+      src="/@vite/client"
+      async
+    >
+    </script>
+    <script
+      type="module"
       src="/@visle/bootstrap"
       async
     >
@@ -194,6 +254,12 @@ exports[`Dev Server SSR > 'Full HTML document with head/body' 1`] = `
 exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -211,6 +277,12 @@ exports[`Dev Server SSR > 'Island with alias import' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -235,6 +307,12 @@ exports[`Dev Server SSR > 'Island with barrel import' 1`] = `
 exports[`Dev Server SSR > 'Island with named import' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -257,6 +335,12 @@ exports[`Dev Server SSR > 'Island with named import' 1`] = `
 exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -274,6 +358,12 @@ exports[`Dev Server SSR > 'Island with options API renamed compo…' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Island with options API' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -295,6 +385,12 @@ exports[`Dev Server SSR > 'Island with options API' 1`] = `
 exports[`Dev Server SSR > 'Island with props' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -312,6 +408,12 @@ exports[`Dev Server SSR > 'Island with props' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Markdown entry component' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div>
   <h1>
     Hello Markdown
@@ -323,6 +425,12 @@ exports[`Dev Server SSR > 'Markdown entry component' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Multiple islands on the same page' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -344,6 +452,12 @@ exports[`Dev Server SSR > 'Multiple islands on the same page' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Named export' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -370,6 +484,12 @@ exports[`Dev Server SSR > 'Named export' 1`] = `
 exports[`Dev Server SSR > 'Nested island' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -389,6 +509,12 @@ exports[`Dev Server SSR > 'Nested island' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Non-ascii file name' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <p>
   Non-ascii file name
 </p>
@@ -399,6 +525,12 @@ exports[`Dev Server SSR > 'SVG image asset' 1`] = `
   rel="stylesheet"
   href="/pages/with-svg-img.vue?vue&type=style&index=0&lang.css"
 >
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <script
   type="module"
   src="/@visle/bootstrap"
@@ -424,6 +556,12 @@ exports[`Dev Server SSR > 'SVG image asset' 1`] = `
 exports[`Dev Server SSR > 'Same component as island and server' 1`] = `
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -444,6 +582,12 @@ exports[`Dev Server SSR > 'Same component as island and server' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Server component with slot' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div class="layout">
   <header>
     Header
@@ -471,6 +615,12 @@ exports[`Dev Server SSR > 'Shared CSS common chunk' 1`] = `
 >
 <script
   type="module"
+  src="/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/@visle/bootstrap"
   async
 >
@@ -488,6 +638,12 @@ exports[`Dev Server SSR > 'Shared CSS common chunk' 1`] = `
 `;
 
 exports[`Dev Server SSR > 'Static component rendering' 1`] = `
+<script
+  type="module"
+  src="/@vite/client"
+  async
+>
+</script>
 <div>
   Hello World
 </div>

--- a/test/__snapshots__/integrated.test.ts.snap
+++ b/test/__snapshots__/integrated.test.ts.snap
@@ -11,6 +11,12 @@ exports[`Integrated development server > renders a component with its resolved d
 >
 <script
   type="module"
+  src="/base/@vite/client"
+  async
+>
+</script>
+<script
+  type="module"
   src="/base/@visle/bootstrap"
   async
 >


### PR DESCRIPTION
Currently, pages without island components does not handle HMR because Visle does not inject `/@vite/client`. It handles HMR when there are islands because Vite Vue plugin imports Vite client under the hood.

In this PR, injecting `/@vite/client` in all pages so that HMR triggered by CSS update can be handled. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development pages now automatically load the Vite client for improved hot-reload support.
  - Island pages continue to load their required bootstrap script alongside the development client.
  - Bootstrap assets are assembled consistently for both development and production rendering.

- **Bug Fixes**
  - Corrected development client URL generation when a custom server origin or base path is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->