### PR TITLE
refactor(build): tidy up cluttered logic

### DIFF
--- a/src/build/generate.ts
+++ b/src/build/generate.ts
@@ -1,17 +1,13 @@
-import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
+import { islandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
 import { manifestFileName } from '../shared/manifest.js'
 import type { BuildManifest } from '../shared/manifest.js'
-import { type AbsolutePath, type RelativePath, relative } from '../shared/path.js'
+import { type AbsolutePath, type RelativePath, relative, resolve } from '../shared/path.js'
 import { stripEntryExt } from './paths.js'
 
 export const viteEntriesId = 'virtual:visle/vite-entries'
-export const resolvedViteEntriesId = `\0${viteEntriesId}`
 export const viteManifestId = 'virtual:visle/vite-manifest'
-export const resolvedViteManifestId = `\0${viteManifestId}`
 export const viteEntryCssPrefix = 'virtual:visle/vite-entry-css/'
-export const resolvedViteEntryCssPrefix = `\0${viteEntryCssPrefix}`
 export const serverEntriesId = 'virtual:visle/server-entries'
-export const resolvedServerEntriesId = `\0${serverEntriesId}`
 
 export const serverEntryFileName = 'server-entry.js'
 export const bundleFileName = 'visle-bundle.js'
@@ -71,19 +67,27 @@ export default bundle
 }
 
 /** Generate production manifest data for the Vite-backed server loader. */
-export function generateIntegratedManifestCode(manifest: BuildManifest): string {
+export function generateVirtualManifestCode(manifest: BuildManifest): string {
   return `export default ${JSON.stringify(manifest)}\n`
 }
 
 /** Generate a development manifest with lazy per-entry CSS resolution. */
-export function generateIntegratedDevManifestCode(
-  base: string,
-  entryDir: string,
-  entryExt: string[],
-  entries: Record<string, string>,
+export function generateVirtualDevManifestCode(
+  config: {
+    root: AbsolutePath
+    base: string
+    entryDir: string
+    entryExt: string[]
+  },
+  entryComponentIds: AbsolutePath[],
 ): string {
-  const cssMap = Object.entries(entries)
-    .map(([entryRelativePath, componentPath]) => {
+  const cssMap = entryComponentIds
+    .map((componentId) => {
+      const entryRelativePath = relative(config.root, componentId)
+      const componentPath = stripEntryExt(
+        relative(resolve(config.root, config.entryDir), componentId),
+        config.entryExt,
+      )
       const cssModuleId = viteEntryCssPrefix + encodeURIComponent(componentPath)
       return `    ${JSON.stringify(entryRelativePath)}: () => import(${JSON.stringify(cssModuleId)}).then(({ default: cssIds }) => cssIds)`
     })
@@ -96,14 +100,12 @@ export function generateIntegratedDevManifestCode(
 })
 
 export default {
-  base: ${JSON.stringify(base)},
-  entryDir: ${JSON.stringify(entryDir)},
-  entryExt: ${JSON.stringify(entryExt)},
-  cssMap: {
-${cssMap}
-  },
+  base: ${JSON.stringify(config.base)},
+  entryDir: ${JSON.stringify(config.entryDir)},
+  entryExt: ${JSON.stringify(config.entryExt)},
+  cssMap: {\n${cssMap}},
   jsMap,
-  islandsBootstrap: ${JSON.stringify(virtualIslandsBootstrapPath)},
+  islandsBootstrap: ${JSON.stringify(islandsBootstrapPath)},
   devClient: ${JSON.stringify(viteDevClientPath)},
 }
 `

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -44,6 +44,33 @@ export function visle(config: VisleConfig = {}): Plugin[] {
   const virtualFile = virtualFilePlugin(resolvedConfig, getBuildManifest)
   const vuePlugin = wrapVuePlugin(resolvedConfig)
 
+  /**
+   * Setting island component paths to the client environment input.
+   */
+  const clientInputPlugin: Plugin = {
+    name: 'visle:client-input',
+    sharedDuringBuild: true,
+
+    applyToEnvironment: (env) => env.name === 'client',
+
+    options(opts) {
+      if (islandPaths.size === 0) {
+        return null
+      }
+
+      if (!Array.isArray(opts.input) && typeof opts.input !== 'string') {
+        this.error(
+          'It is not allowed to pass an object value to the input option of the client environment',
+        )
+      }
+
+      // Update client environment input with paths discovered during style build
+      const existing = Array.isArray(opts.input) ? opts.input : [opts.input]
+
+      return { ...opts, input: [...existing, ...islandPaths] }
+    },
+  }
+
   const orchestrationPlugin: Plugin = {
     name: 'visle:orchestration',
 
@@ -63,6 +90,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             },
           },
         },
+
         client: {
           consumer: 'client',
           build: {
@@ -76,6 +104,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             },
           },
         },
+
         ssr: {
           consumer: 'server',
           resolve: {
@@ -149,30 +178,6 @@ export function visle(config: VisleConfig = {}): Plugin[] {
 
     configResolved(viteConfig) {
       setVisleConfig(viteConfig, resolvedConfig)
-    },
-  }
-
-  const clientInputPlugin: Plugin = {
-    name: 'visle:client-input',
-    sharedDuringBuild: true,
-
-    applyToEnvironment: (env) => env.name === 'client',
-
-    options(opts) {
-      if (islandPaths.size === 0) {
-        return null
-      }
-
-      if (!Array.isArray(opts.input) && typeof opts.input !== 'string') {
-        this.error(
-          'It is not allowed to pass an object value to the input option of the client environment',
-        )
-      }
-
-      // Update client environment input with paths discovered during style build
-      const existing = Array.isArray(opts.input) ? opts.input : [opts.input]
-
-      return { ...opts, input: [...existing, ...islandPaths] }
     },
   }
 

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -21,7 +21,7 @@ import { islandComponentsPlugin } from './plugins/island-components.js'
 import { manifestPlugin } from './plugins/manifest.js'
 import { serverTransformPlugin } from './plugins/server-transform.js'
 import { virtualFilePlugin } from './plugins/virtual-file.js'
-import { wrapVuePlugin } from './vue.js'
+import { wrapVuePlugin } from './plugins/vue.js'
 
 export type { VisleConfig }
 

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -14,13 +14,13 @@ import {
   serverEntriesId,
   serverEntryFileName,
 } from './generate.js'
-import { islandsBootstrapPath, resolveServerComponentIds } from './paths.js'
+import { realIslandsBootstrapPath, resolveServerComponentIds } from './paths.js'
 import { devStyleSSRPlugin } from './plugins/dev-style-ssr.js'
 import { entryTypesPlugin } from './plugins/entry-types.js'
 import { islandComponentsPlugin } from './plugins/island-components.js'
 import { manifestPlugin } from './plugins/manifest.js'
 import { serverTransformPlugin } from './plugins/server-transform.js'
-import { virtualFilePlugin } from './plugins/virtual-file.js'
+import { virtualFilePlugins } from './plugins/virtual-file.js'
 import { wrapVuePlugin } from './plugins/vue.js'
 
 export type { VisleConfig }
@@ -41,7 +41,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
   const { plugin: manifest, getBuildManifest } = manifestPlugin(resolvedConfig)
   const { plugin: entryTypes, generate: generateEntryTypes } = entryTypesPlugin(resolvedConfig)
   const serverTransform = serverTransformPlugin(resolvedConfig.entryExt)
-  const virtualFile = virtualFilePlugin(resolvedConfig, getBuildManifest)
+  const virtualFile = virtualFilePlugins(resolvedConfig, getBuildManifest)
   const vuePlugin = wrapVuePlugin(resolvedConfig)
 
   /**
@@ -99,7 +99,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
             rollupOptions: {
               // Start with islands bootstrap;
               // v-client island paths are added after the style build
-              input: [islandsBootstrapPath],
+              input: [realIslandsBootstrapPath],
               preserveEntrySignatures: 'allow-extension',
             },
           },
@@ -186,7 +186,7 @@ export function visle(config: VisleConfig = {}): Plugin[] {
     clientInputPlugin,
     islandComponents,
     serverTransform,
-    virtualFile,
+    ...virtualFile,
     manifest,
     entryTypes,
     vuePlugin,

--- a/src/build/paths.ts
+++ b/src/build/paths.ts
@@ -8,7 +8,7 @@ import { componentWrapPrefix } from './generate.js'
 // -----------------------------
 // Custom Element Paths
 // -----------------------------
-export const islandsBootstrapPath = resolve(
+export const realIslandsBootstrapPath = resolve(
   // In Deno, import.meta.dirname can be undefined (in https module).
   // Just casting it to string for now.
   // oxlint-disable-next-line typescript/no-unnecessary-type-assertion

--- a/src/build/plugins/manifest.ts
+++ b/src/build/plugins/manifest.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'vite'
 import type { ResolvedVisleConfig } from '../../shared/config.js'
 import type { BuildManifest } from '../../shared/manifest.js'
 import { asAbs, relative } from '../../shared/path.js'
-import { islandsBootstrapPath } from '../paths.js'
+import { realIslandsBootstrapPath } from '../paths.js'
 
 interface ManifestPluginResult {
   plugin: Plugin
@@ -113,7 +113,7 @@ export function manifestPlugin(visleConfig: ResolvedVisleConfig): ManifestPlugin
           }
 
           // The chunk is islands bootstrap that is Visle-provided
-          if (chunk.facadeModuleId === islandsBootstrapPath) {
+          if (chunk.facadeModuleId === realIslandsBootstrapPath) {
             islandsBootstrap = chunk.fileName
             continue
           }

--- a/src/build/plugins/server-transform.ts
+++ b/src/build/plugins/server-transform.ts
@@ -19,6 +19,30 @@ export function serverTransformPlugin(entryExt: string[]): Plugin {
    */
   const componentNameMap = new Map<string, Map<string, Set<string>>>()
 
+  function registerComponentName({
+    importerPath,
+    sourcePath,
+    importedName,
+  }: {
+    importerPath: string
+    sourcePath: string
+    importedName: string
+  }): void {
+    let nameMap = componentNameMap.get(importerPath)
+    if (!nameMap) {
+      nameMap = new Map()
+      componentNameMap.set(importerPath, nameMap)
+    }
+
+    let names = nameMap.get(sourcePath)
+    if (!names) {
+      names = new Set()
+      nameMap.set(sourcePath, names)
+    }
+
+    names.add(importedName)
+  }
+
   let viteConfig: ResolvedConfig
 
   return {
@@ -124,17 +148,11 @@ export function serverTransformPlugin(entryExt: string[]): Plugin {
         }
 
         // Record import name so resolveId can include it in the names query
-        let nameMap = componentNameMap.get(fileName)
-        if (!nameMap) {
-          nameMap = new Map()
-          componentNameMap.set(fileName, nameMap)
-        }
-        let names = nameMap.get(resolvedPath)
-        if (!names) {
-          names = new Set()
-          nameMap.set(resolvedPath, names)
-        }
-        names.add(importInfo.importedName)
+        registerComponentName({
+          importerPath: fileName,
+          sourcePath: resolvedPath,
+          importedName: importInfo.importedName,
+        })
       }
 
       return null

--- a/src/build/plugins/virtual-file.test.ts
+++ b/src/build/plugins/virtual-file.test.ts
@@ -2,8 +2,8 @@ import { createServer, type ViteDevServer } from 'vite'
 import { describe, test, expect, afterEach } from 'vite-plus/test'
 
 import { defaultConfig } from '../../shared/config.ts'
-import { virtualIslandsBootstrapPath } from '../../shared/entry.ts'
-import { virtualFilePlugin } from './virtual-file.ts'
+import { islandsBootstrapPath } from '../../shared/entry.ts'
+import { virtualFilePlugins } from './virtual-file.ts'
 
 describe('virtualFilePlugin', () => {
   let server: ViteDevServer | undefined
@@ -17,7 +17,7 @@ describe('virtualFilePlugin', () => {
     server = await createServer({
       configFile: false,
       plugins: [
-        virtualFilePlugin(defaultConfig, () => {
+        virtualFilePlugins(defaultConfig, () => {
           throw new Error('manifest should not be requested')
         }),
       ],
@@ -27,7 +27,7 @@ describe('virtualFilePlugin', () => {
       logLevel: 'silent',
     })
 
-    const result = await server.environments.client.transformRequest(virtualIslandsBootstrapPath)
+    const result = await server.environments.client.transformRequest(islandsBootstrapPath)
 
     expect(result).not.toBeNull()
     expect(result!.code).toContain('vue-island')

--- a/src/build/plugins/virtual-file.ts
+++ b/src/build/plugins/virtual-file.ts
@@ -1,136 +1,215 @@
-import type { Plugin, ViteDevServer } from 'vite'
+import type { DevEnvironment, Environment, Plugin, ViteDevServer } from 'vite'
 
 import { collectDevEntryCssIds } from '../../dev/style.js'
 import type { ResolvedVisleConfig } from '../../shared/config.js'
-import { virtualIslandsBootstrapPath } from '../../shared/entry.js'
+import { islandsBootstrapPath } from '../../shared/entry.js'
 import type { BuildManifest } from '../../shared/manifest.js'
 import { type AbsolutePath, asAbs, relative, resolve } from '../../shared/path.js'
 import {
-  generateIntegratedDevManifestCode,
-  generateIntegratedManifestCode,
+  generateVirtualDevManifestCode,
+  generateVirtualManifestCode,
   generateServerVirtualEntryCode,
-  resolvedViteEntriesId,
-  resolvedViteEntryCssPrefix,
-  resolvedViteManifestId,
-  resolvedServerEntriesId,
   serverEntriesId,
   viteEntriesId,
   viteEntryCssPrefix,
   viteManifestId,
 } from '../generate.js'
-import { islandsBootstrapPath, resolveServerComponentIds, stripEntryExt } from '../paths.js'
+import { realIslandsBootstrapPath, resolveServerComponentIds, stripEntryExt } from '../paths.js'
 
 /**
  * Vite plugin that resolves and loads virtual entry modules per environment.
  */
-export function virtualFilePlugin(
+export function virtualFilePlugins(
   config: ResolvedVisleConfig,
   getBuildManifest: () => BuildManifest,
-): Plugin {
-  let command: 'build' | 'serve'
-  let entryRoot: AbsolutePath
-  let root: AbsolutePath
-  let base: string
-  let devServer: ViteDevServer | undefined
-
-  function componentIds(): AbsolutePath[] {
-    return resolveServerComponentIds(entryRoot, config.entryExt)
+): Plugin[] {
+  function entryDir(env: Environment): AbsolutePath {
+    const root = asAbs(env.config.root)
+    return resolve(root, config.entryDir)
   }
 
+  function componentIds(env: Environment): AbsolutePath[] {
+    return resolveServerComponentIds(entryDir(env), config.entryExt)
+  }
+
+  return [
+    vfsRedirectPlugin({
+      name: 'islands-bootstrap',
+      from: islandsBootstrapPath,
+      to: realIslandsBootstrapPath,
+    }),
+
+    vfsLoadPlugin({
+      name: 'server-entries',
+      filter: (id) => id === serverEntriesId,
+      load() {
+        return generateServerVirtualEntryCode(
+          entryDir(this.environment),
+          componentIds(this.environment),
+          config.entryExt,
+          false,
+        )
+      },
+    }),
+
+    vfsLoadPlugin({
+      name: 'vite-entries',
+      filter: (id) => id === viteEntriesId,
+      load() {
+        return generateServerVirtualEntryCode(
+          entryDir(this.environment),
+          componentIds(this.environment),
+          config.entryExt,
+          true,
+        )
+      },
+    }),
+
+    vfsLoadPlugin({
+      name: 'vite-manifest',
+      filter: (id) => id === viteManifestId,
+      load() {
+        if (this.environment.config.command === 'build') {
+          return generateVirtualManifestCode(getBuildManifest())
+        }
+
+        return generateVirtualDevManifestCode(
+          {
+            root: asAbs(this.environment.config.root),
+            base: this.environment.config.base,
+            entryDir: config.entryDir,
+            entryExt: config.entryExt,
+          },
+          componentIds(this.environment),
+        )
+      },
+    }),
+
+    vfsLoadPlugin({
+      name: 'entry-css',
+
+      filter(id) {
+        return this.environment.config.command === 'serve' && id.startsWith(viteEntryCssPrefix)
+      },
+
+      async load(id) {
+        const componentPath = decodeURIComponent(id.slice(viteEntryCssPrefix.length))
+        const componentId = componentIds(this.environment).find(
+          (candidate) =>
+            stripEntryExt(relative(entryDir(this.environment), candidate), config.entryExt) ===
+            componentPath,
+        )
+        if (componentId) {
+          this.addWatchFile(componentId)
+        }
+
+        const cssUrls = await collectDevEntryCssIds(
+          this.server,
+          this.serverEnvironment,
+          componentPath,
+          {
+            onModule: (module) => {
+              if (module.file) {
+                this.addWatchFile(module.file)
+              }
+            },
+          },
+        )
+        return `export default ${JSON.stringify(cssUrls)}\n`
+      },
+    }),
+  ]
+}
+
+interface PluginContext {
+  environment: Environment
+  server: ViteDevServer
+  serverEnvironment: DevEnvironment
+  error: (message: string) => never
+  addWatchFile: (id: string) => void
+}
+
+function vfsLoadPlugin({
+  name,
+  filter,
+  load,
+}: {
+  name: string
+  filter: (this: PluginContext, id: string) => boolean
+  load: (this: PluginContext, id: string) => string | Promise<string>
+}): Plugin {
+  type VitePluginContext = Plugin['resolveId'] extends infer F
+    ? F extends (this: infer R, ...args: infer _Args) => infer _Return
+      ? R
+      : never
+    : never
+
+  function ctxOf(viteCtx: VitePluginContext): PluginContext {
+    return {
+      get environment() {
+        return viteCtx.environment
+      },
+
+      get server(): ViteDevServer {
+        if (!devServer) {
+          viteCtx.error(`[visle] ${name} resolution requires a running Vite dev server.`)
+        }
+
+        return devServer
+      },
+
+      get serverEnvironment(): DevEnvironment {
+        const serverEnvironment = this.server.environments[this.environment.name]
+        if (!serverEnvironment) {
+          viteCtx.error(`[visle] No server environment is available for ${name} resolution.`)
+        }
+
+        return serverEnvironment
+      },
+
+      error: (message) => viteCtx.error(message),
+      addWatchFile: (id) => viteCtx.addWatchFile(id),
+    }
+  }
+
+  let devServer: ViteDevServer | undefined
+
   return {
-    name: 'visle:virtual-file',
+    name: `visle:virtual:${name}`,
     enforce: 'pre',
     sharedDuringBuild: true,
-
-    configResolved(resolvedConfig) {
-      command = resolvedConfig.command
-      root = asAbs(resolvedConfig.root)
-      entryRoot = resolve(root, config.entryDir)
-      base = resolvedConfig.base
-    },
 
     configureServer(server) {
       devServer = server
     },
 
     resolveId(id) {
-      if (id === virtualIslandsBootstrapPath) {
-        return islandsBootstrapPath
-      }
-
-      if (id === serverEntriesId) {
-        return resolvedServerEntriesId
-      }
-
-      if (config.serverBuild === 'integrated' && this.environment.config.consumer === 'server') {
-        if (id === viteEntriesId) {
-          return resolvedViteEntriesId
-        }
-
-        if (id === viteManifestId) {
-          return resolvedViteManifestId
-        }
-
-        if (command === 'serve' && id.startsWith(viteEntryCssPrefix)) {
-          return resolvedViteEntryCssPrefix + id.slice(viteEntryCssPrefix.length)
-        }
+      if (filter.call(ctxOf(this), id)) {
+        return `\0${id}`
       }
 
       return null
     },
 
     async load(id) {
-      if (id === resolvedServerEntriesId || id === resolvedViteEntriesId) {
-        return generateServerVirtualEntryCode(
-          entryRoot,
-          componentIds(),
-          config.entryExt,
-          id === resolvedViteEntriesId,
-        )
+      if (id.charAt(0) === '\0' && filter.call(ctxOf(this), id.slice(1))) {
+        return load.call(ctxOf(this), id.slice(1))
       }
 
-      if (id === resolvedViteManifestId) {
-        if (command === 'build') {
-          return generateIntegratedManifestCode(getBuildManifest())
-        }
+      return null
+    },
+  }
+}
 
-        const entries = Object.fromEntries(
-          componentIds().map((componentId) => [
-            relative(root, componentId),
-            stripEntryExt(relative(entryRoot, componentId), config.entryExt),
-          ]),
-        )
-        return generateIntegratedDevManifestCode(base, config.entryDir, config.entryExt, entries)
-      }
+function vfsRedirectPlugin({ name, from, to }: { name: string; from: string; to: string }): Plugin {
+  return {
+    name: `visle:virtual:${name}`,
+    enforce: 'pre',
+    sharedDuringBuild: true,
 
-      if (id.startsWith(resolvedViteEntryCssPrefix)) {
-        if (!devServer) {
-          this.error('[visle] Development CSS resolution requires a running Vite dev server.')
-        }
-        const server = devServer
-
-        const serverEnvironment = server.environments[this.environment.name]
-        if (!serverEnvironment) {
-          this.error('[visle] No server environment is available for development CSS resolution.')
-        }
-
-        const componentPath = decodeURIComponent(id.slice(resolvedViteEntryCssPrefix.length))
-        const componentId = componentIds().find(
-          (candidate) =>
-            stripEntryExt(relative(entryRoot, candidate), config.entryExt) === componentPath,
-        )
-        if (componentId) {
-          this.addWatchFile(componentId)
-        }
-
-        const cssUrls = await collectDevEntryCssIds(server, serverEnvironment, componentPath, {
-          onModule: (module) => {
-            if (module.file) {
-              this.addWatchFile(module.file)
-            }
-          },
-        })
-        return `export default ${JSON.stringify(cssUrls)}\n`
+    resolveId(id) {
+      if (id === from) {
+        return to
       }
 
       return null

--- a/src/build/plugins/vue.test.ts
+++ b/src/build/plugins/vue.test.ts
@@ -5,10 +5,10 @@ import { createObjectProperty, createSimpleExpression } from '@vue/compiler-core
 import { createServer, type ViteDevServer } from 'vite'
 import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
-import { defaultConfig, type ResolvedVisleConfig } from '../shared/config.ts'
+import { defaultConfig, type ResolvedVisleConfig } from '../../shared/config.ts'
 import { wrapVuePlugin } from './vue.ts'
 
-const root = path.resolve(__dirname, '..', '..')
+const root = path.resolve(__dirname, '../../..')
 const tempDir = path.resolve(root, 'test/__generated__/server/vue-plugin')
 
 describe('wrapVuePlugin', () => {

--- a/src/build/plugins/vue.ts
+++ b/src/build/plugins/vue.ts
@@ -1,8 +1,8 @@
 import vuePlugin from '@vitejs/plugin-vue'
 import { createObjectProperty, createSimpleExpression, NodeTypes } from '@vue/compiler-core'
 
-import { generateComponentId } from '../shared/component-id.js'
-import type { ResolvedVisleConfig } from '../shared/config.js'
+import { generateComponentId } from '../../shared/component-id.js'
+import type { ResolvedVisleConfig } from '../../shared/config.js'
 
 /**
  * Wrap @vitejs/plugin-vue to inject Visle specific options.

--- a/src/dev/manifest.test.ts
+++ b/src/dev/manifest.test.ts
@@ -5,7 +5,7 @@ import { createServer, type ViteDevServer } from 'vite'
 import { afterEach, beforeEach, describe, expect, test } from 'vite-plus/test'
 
 import { visle } from '../build/index.ts'
-import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.ts'
+import { islandsBootstrapPath, viteDevClientPath } from '../shared/entry.ts'
 import { createDevManifest } from './manifest.ts'
 
 const generatedDir = path.resolve(import.meta.dirname, '../../test/__generated__/dev')
@@ -64,7 +64,7 @@ describe('createDevManifest', () => {
 
     await expect(manifest.getBootstrapJsIds(true)).resolves.toEqual([
       viteDevClientPath,
-      virtualIslandsBootstrapPath,
+      islandsBootstrapPath,
     ])
   })
 

--- a/src/dev/manifest.ts
+++ b/src/dev/manifest.ts
@@ -1,7 +1,7 @@
 import type { ViteDevServer } from 'vite'
 
 import type { RuntimeManifest } from '../server/manifest.js'
-import { virtualIslandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
+import { islandsBootstrapPath, viteDevClientPath } from '../shared/entry.js'
 import { getServerEnvironment } from './index.js'
 import { collectDevEntryCssIds } from './style.js'
 
@@ -25,7 +25,7 @@ export function createDevManifest(devServer: ViteDevServer): RuntimeManifest {
     async getBootstrapJsIds(hasIsland: boolean): Promise<string[]> {
       const ids = [applyServeBase(viteDevClientPath)]
       if (hasIsland) {
-        ids.push(applyServeBase(virtualIslandsBootstrapPath))
+        ids.push(applyServeBase(islandsBootstrapPath))
       }
       return ids
     },

--- a/src/shared/entry.ts
+++ b/src/shared/entry.ts
@@ -1,7 +1,7 @@
 /**
  * Path to client bootstrap script that the browser request to.
  */
-export const virtualIslandsBootstrapPath = '/@visle/bootstrap'
+export const islandsBootstrapPath = '/@visle/bootstrap'
 
 /**
  * Path to Vite's development client.


### PR DESCRIPTION
- Split virtual file plugin for each file so that the responsibility is clearer
- Remove resolved* virtual file constants since it is resolved each virtual file plugin internally
- Extract low level logic to a function
- Rename/reorder some variables and functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved development and production manifest generation, including configurable entry paths and preserved lazy CSS loading.
  * Enhanced support for multiple virtual file plugins and environment-specific build output.
  * Improved discovery and inclusion of island components during client builds.

* **Refactor**
  * Standardized bootstrap path and virtual manifest naming across build and development workflows.
  * Simplified component name registration and updated related build integrations.

* **Tests**
  * Updated build and development coverage for the revised virtual file and bootstrap handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->